### PR TITLE
Implement program parameters

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
         rust:
           - stable
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: ${{ matrix.rust }}
@@ -41,7 +41,7 @@ jobs:
         rust:
           - stable
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: ${{ matrix.rust }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,5 +40,5 @@ lto = true
 [patch.crates-io]
 iced = { git = "https://github.com/fengalin/iced", branch = "subscription-unfold-none-handling" }
 iced_graphics = { git = "https://github.com/fengalin/iced", branch = "subscription-unfold-none-handling" }
-iced_native = { git = "https://github.com/fengalin/iced", branch = "subscription-unfold-none-handling" }
 iced_lazy = { git = "https://github.com/fengalin/iced", branch = "subscription-unfold-none-handling" }
+iced_native = { git = "https://github.com/fengalin/iced", branch = "subscription-unfold-none-handling" }

--- a/src/jstation/channel_voice.rs
+++ b/src/jstation/channel_voice.rs
@@ -1,0 +1,30 @@
+use crate::{
+    jstation::{CCParameter, Error, ProgramNumber},
+    midi,
+};
+
+#[derive(Copy, Clone, Debug)]
+pub struct ChannelVoice {
+    pub chan: midi::Channel,
+    pub msg: Message,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum Message {
+    CC(CCParameter),
+    ProgramChange(ProgramNumber),
+}
+
+impl TryFrom<midi::ChannelVoice> for ChannelVoice {
+    type Error = Error;
+
+    fn try_from(cv: midi::ChannelVoice) -> Result<Self, Self::Error> {
+        use midi::channel_voice::Message::*;
+        let msg = match cv.msg {
+            CC(cc) => Message::CC(CCParameter::try_from(cc)?),
+            ProgramChange(prog_nb) => Message::ProgramChange(ProgramNumber::from(prog_nb)),
+        };
+
+        Ok(ChannelVoice { chan: cv.chan, msg })
+    }
+}

--- a/src/jstation/data/dsp/amp.rs
+++ b/src/jstation/data/dsp/amp.rs
@@ -1,0 +1,74 @@
+use crate::{
+    jstation::data::{Normal, ParameterNumber, RawValue},
+    midi::CCNumber,
+};
+
+discrete_parameter!(AmpModeling {
+    const DEFAULT = Normal::MIN,
+    const MAX_RAW = RawValue::new(24),
+    const PARAMETER_NB = ParameterNumber::new(9),
+    const CC_NB = CCNumber::new(34),
+});
+
+pub static NAMES: [(&str, &str); 25] = [
+    ("J Crunch", "JM150 Millennium Crunch"),
+    ("J Solo", "JM150 Millennium Solo"),
+    ("J Clean", "JM150 Millennium Clean"),
+    ("Boutique", "Matchless DC30"),
+    ("Rectified", "MesaBoogie Dual Rectifier"),
+    ("Brit Stack", "Marshall JCM900"),
+    ("Brit Class A", "'63 Vox AC30 top boost"),
+    ("BlackFace", "'65 Fender Twin Reverb"),
+    ("Boat Back", "piezo acoustic guitar"),
+    ("Flat Top", "dreadnaught acoustic guitar"),
+    ("Hot Rod", "Mesa Boogie Mark II C"),
+    ("Tweed", "'57 Fender Tweed Deluxe"),
+    ("Blues", "dynamic blues tube combo"),
+    ("Fuzz", "60's fuzz tone"),
+    ("Modern", "SWR bass"),
+    ("British", "Trace Elliot bass amp"),
+    ("Rock", "Ampeg SVT bass amp"),
+    ("Hiwatt (A1)", "Hiwatt Custom 50"),
+    ("Brit Master Vol (A2)", "'78 Marshall Mstr Volume"),
+    ("Brit 800 EL84 (A3)", "'81 Marshall JCM800 w/EL34s"),
+    ("Band Master (A4)", "'72 Fender Bandmaster"),
+    ("Bass Man (A5)", "'65 Fender Bassman"),
+    ("Stella Bass (A6)", "SWR Interstellar Odrive"),
+    ("'83 Concert (A7)", "'83 Fender Concert Head"),
+    ("Direct (A8)", "Direct - no modelling"),
+];
+
+discrete_parameter!(Gain {
+    const DEFAULT = Normal::MIN,
+    const MAX_RAW = RawValue::new(90),
+    const PARAMETER_NB = ParameterNumber::new(10),
+    const CC_NB = CCNumber::new(35),
+});
+
+discrete_parameter!(Treble {
+    const DEFAULT = Normal::HALF,
+    const MAX_RAW = RawValue::new(90),
+    const PARAMETER_NB = ParameterNumber::new(11),
+    const CC_NB = CCNumber::new(39),
+});
+
+discrete_parameter!(Middle {
+    const DEFAULT = Normal::HALF,
+    const MAX_RAW = RawValue::new(90),
+    const PARAMETER_NB = ParameterNumber::new(12),
+    const CC_NB = CCNumber::new(38),
+});
+
+discrete_parameter!(Bass {
+    const DEFAULT = Normal::HALF,
+    const MAX_RAW = RawValue::new(90),
+    const PARAMETER_NB = ParameterNumber::new(13),
+    const CC_NB = CCNumber::new(37),
+});
+
+discrete_parameter!(Level {
+    const DEFAULT = Normal::MIN,
+    const MAX_RAW = RawValue::new(90),
+    const PARAMETER_NB = ParameterNumber::new(14),
+    const CC_NB = CCNumber::new(36),
+});

--- a/src/jstation/data/dsp/cabinet.rs
+++ b/src/jstation/data/dsp/cabinet.rs
@@ -1,0 +1,33 @@
+use crate::{
+    jstation::data::{Normal, ParameterNumber, RawValue},
+    midi::CCNumber,
+};
+
+discrete_parameter!(Cabinet {
+    const DEFAULT = Normal::MIN,
+    const MAX_RAW = RawValue::new(18),
+    const PARAMETER_NB = ParameterNumber::new(15),
+    const CC_NB = CCNumber::new(66),
+});
+
+pub static NAMES: [(&str, &str); 19] = [
+    ("No Cabinet", ""),
+    ("British 4x12", "Marshall 1960A with 75W Celestions"),
+    ("Johnson 4x12", "loaded with Vintage 30W Celestions"),
+    ("Fane 4x12", "Hiwatt SE4123 with Fanes",),
+    ("Johnson 2x12", "Open back with Vintage 30W Celestions"),
+    ("American 2x12", "Fender Twin 2x12"),
+    ("Jennings Blue 2x12", "'63 Vox AC30"),
+    ("Tweed 1x12", "Fender Deluxe 1x12"),
+    ("Blonde 2x12", "Bassman 2x12"),
+    ("Bass 4x10 with Tweeter", "SWR 4x10 with tweeter"),
+    ("Bass 360 1x18", "Acoustic 360"),
+    ("Flex Bass 1x15", "Ampeg Portaflex"),
+    ("Green Back 4x12", "Marshall 1960B with 25W Celestion Greenbacks"),
+    ("Mega 1516", "Peavy 1x15 and 2x8"),
+    ("Boutique 4x12", "VHT 4x12 with Celestion V30s"),
+    ("'65 Tweed 1x12", "'65 Fender Deluxe"),
+    ("Goliath 4x10", "SWR Goliath"),
+    ("Ivy League 1x10", "Fender Harvard"),
+    ("Bass Man 4x10", "Fender Bassman"),
+];

--- a/src/jstation/data/dsp/mod.rs
+++ b/src/jstation/data/dsp/mod.rs
@@ -1,0 +1,54 @@
+use crate::{jstation::Error, midi::CC};
+
+macro_rules! declare_cc_params(
+    ( $( $module:ident: $( $cc_param:ident $(,)? )*; )* ) => {
+        $(
+            mod $module;
+            pub use $module::{$( $cc_param, )*};
+        )*
+
+        #[derive(Copy, Clone, Debug)]
+        pub enum CCParameter {
+            $( $(
+                $cc_param($cc_param),
+            )* )*
+        }
+
+        $( $(
+            impl From<$cc_param> for CCParameter {
+                fn from(cc_param: $cc_param) -> Self {
+                    CCParameter::$cc_param(cc_param)
+                }
+            }
+        )* )*
+
+        impl TryFrom<CC> for CCParameter {
+            type Error = Error;
+
+            fn try_from(cc: CC) -> Result<Self, Self::Error> {
+                use crate::jstation::data::{BoolCCParameter, DiscreteCCParameter};
+
+                match cc.nb {
+                    $( $(
+                        $cc_param::CC_NB => {
+                            Ok(CCParameter::$cc_param($cc_param::from_cc(cc.value)))
+                        }
+                    )* )*
+                    _ => {
+                        let err = Error::CCNumber(cc.nb.as_u8());
+                        log::warn!("{err}");
+
+                        Err(err)
+                    }
+                }
+            }
+        }
+    };
+);
+
+declare_cc_params!(
+    amp: AmpModeling, Gain, Treble, Middle, Bass, Level;
+    cabinet: Cabinet;
+    noise_gate: NoiseGateOn, NoiseGateAttackTime, NoiseGateThreshold;
+    utility_settings: DigitalOutLevel;
+);

--- a/src/jstation/data/dsp/noise_gate.rs
+++ b/src/jstation/data/dsp/noise_gate.rs
@@ -1,0 +1,25 @@
+use crate::{
+    jstation::data::{Normal, ParameterNumber, RawValue},
+    midi::CCNumber,
+};
+
+bool_parameter!(NoiseGateOn {
+    const DEFAULT = false,
+    const PARAMETER_NB = ParameterNumber::new(16),
+    const CC_NB = CCNumber::new(41),
+});
+
+discrete_parameter!(NoiseGateAttackTime {
+    const DEFAULT = Normal::MIN,
+    const MAX_RAW = RawValue::new(10),
+    const PARAMETER_NB = ParameterNumber::new(17),
+    const CC_NB = CCNumber::new(42),
+});
+
+discrete_parameter!(NoiseGateThreshold {
+    const DEFAULT = Normal::MIN,
+    const MIN_RAW = RawValue::new(1),
+    const MAX_RAW = RawValue::new(99),
+    const PARAMETER_NB = ParameterNumber::new(18),
+    const CC_NB = CCNumber::new(43),
+});

--- a/src/jstation/data/dsp/utility_settings.rs
+++ b/src/jstation/data/dsp/utility_settings.rs
@@ -1,0 +1,10 @@
+use crate::{
+    jstation::data::{Normal, RawValue},
+    midi::CCNumber,
+};
+
+discrete_parameter!(DigitalOutLevel {
+    const DEFAULT = Normal::MIN,
+    const MAX_RAW = RawValue::new(24),
+    const CC_NB = CCNumber::new(14),
+});

--- a/src/jstation/data/mod.rs
+++ b/src/jstation/data/mod.rs
@@ -1,2 +1,13 @@
+#[macro_use]
+pub mod parameter;
+pub use parameter::{
+    BoolCCParameter, BoolParameter, BoolRawParameter, DiscreteCCParameter, DiscreteParameter,
+    DiscreteRange, DiscreteRawParameter, DiscreteValue, Normal, ParameterNumber, RawParameter,
+    RawValue,
+};
+
+pub mod dsp;
+pub use dsp::CCParameter;
+
 pub mod program;
-pub use program::{Program, ProgramBank};
+pub use program::{Program, ProgramBank, ProgramNumber};

--- a/src/jstation/data/parameter/boolean.rs
+++ b/src/jstation/data/parameter/boolean.rs
@@ -1,0 +1,117 @@
+use crate::{
+    jstation::data::{ParameterNumber, RawParameter, RawValue},
+    midi::{CCNumber, CCValue, CC},
+};
+
+pub trait BoolParameter: From<bool> + Into<bool> + Copy + Clone + std::fmt::Debug + Sized {
+    const DEFAULT: bool;
+
+    /// Resets the parameter to its default value.
+    fn reset(&mut self) {
+        *self = Self::DEFAULT.into();
+    }
+
+    fn value(self) -> bool {
+        self.into()
+    }
+
+    fn set(&mut self, value: bool) {
+        *self = value.into();
+    }
+}
+
+/// A `BoolParameter`, view as a raw `Parameter`, e.g. part of a `Program` `data`.
+pub trait BoolRawParameter: BoolParameter {
+    const PARAMETER_NB: ParameterNumber;
+
+    fn from_raw(raw: RawValue) -> Self {
+        (raw.as_u8() == 0).into()
+    }
+
+    fn to_raw(self) -> RawParameter {
+        let value = RawValue::new(if self.into() { 0 } else { u8::MAX });
+
+        RawParameter::new(Self::PARAMETER_NB, value)
+    }
+}
+
+/// A `BoolParameter`, view as a CC `Parameter`, e.g. part of received as MIDI `CC` message.
+pub trait BoolCCParameter: BoolParameter {
+    const CC_NB: CCNumber;
+
+    fn from_cc(cc_val: CCValue) -> Self {
+        const CC_TRUE_THRESHOLD: u8 = 0x40;
+
+        (cc_val.as_u8() >= CC_TRUE_THRESHOLD).into()
+    }
+
+    fn to_cc(self) -> CC {
+        let value = if self.into() {
+            CCValue::MAX
+        } else {
+            CCValue::ZERO
+        };
+
+        CC::new(Self::CC_NB, value)
+    }
+}
+
+macro_rules! bool_parameter {
+    ($param:ident { const DEFAULT = $default:expr $(,)? } ) => {
+        #[derive(Clone, Copy, Debug)]
+        pub struct $param(bool);
+
+        impl From<bool> for $param {
+            fn from(value: bool) -> Self {
+                $param(value)
+            }
+        }
+
+        impl From<$param> for bool {
+            fn from(value: $param) -> Self {
+                value.0
+            }
+        }
+
+        impl crate::jstation::data::BoolParameter for $param {
+            const DEFAULT: bool = $default;
+        }
+    };
+
+    ( $param:ident {
+        const DEFAULT = $default:expr,
+        const PARAMETER_NB = $param_nb:expr $(,)?
+    } ) => {
+        bool_parameter!($param { const DEFAULT = $default });
+
+        impl crate::jstation::data::BoolRawParameter for $param {
+            const PARAMETER_NB: crate::jstation::data::ParameterNumber = $param_nb;
+        }
+    };
+
+    ( $param:ident {
+        const DEFAULT = $default:expr,
+        const CC_NB = $cc_nb:expr $(,)?
+    } ) => {
+        bool_parameter!($param { const DEFAULT = $default });
+
+        impl crate::jstation::data::BoolCCParameter for $param {
+            const CC_NB: crate::midi::CCNumber = $cc_nb;
+        }
+    };
+
+    ( $param:ident {
+        const DEFAULT = $default:expr,
+        const PARAMETER_NB = $param_nb:expr,
+        const CC_NB = $cc_nb:expr $(,)?
+    } ) => {
+        bool_parameter!($param {
+            const DEFAULT = $default,
+            const PARAMETER_NB = $param_nb
+        });
+
+        impl crate::jstation::data::BoolCCParameter for $param {
+            const CC_NB: crate::jstation::midi::CCNumber = $cc_nb;
+        }
+    };
+}

--- a/src/jstation/data/parameter/discrete.rs
+++ b/src/jstation/data/parameter/discrete.rs
@@ -1,0 +1,380 @@
+use crate::{
+    jstation::{
+        data::{Normal, ParameterNumber, RawParameter, RawValue},
+        Error,
+    },
+    midi::{CCNumber, CCValue, CC},
+};
+
+pub trait DiscreteParameter:
+    From<DiscreteValue> + Into<DiscreteValue> + Copy + Clone + std::fmt::Debug + Sized
+{
+    const DEFAULT: Normal;
+    const MIN_RAW: RawValue;
+    const MAX_RAW: RawValue;
+    const RANGE: crate::jstation::data::DiscreteRange;
+
+    fn from_snapped(normal: Normal) -> Self {
+        DiscreteValue::new(normal, Self::RANGE).into()
+    }
+
+    /// Resets the parameter to its default value.
+    fn reset(&mut self) {
+        *self = DiscreteValue::new(Self::DEFAULT, Self::RANGE).into();
+    }
+
+    /// Sets the value snapping it to its discrete range.
+    fn set(&mut self, normal: Normal) {
+        *self = DiscreteValue::new(normal, Self::RANGE).into();
+    }
+}
+
+/// A `DiscreteParameter`, view as a raw `Parameter`, e.g. part of a `Program` `data`.
+pub trait DiscreteRawParameter: DiscreteParameter {
+    const PARAMETER_NB: ParameterNumber;
+
+    fn try_from_raw(raw: RawValue) -> Result<Self, Error> {
+        DiscreteValue::try_from_raw(raw, Self::RANGE).map(From::from)
+    }
+
+    fn to_raw(self) -> RawParameter {
+        RawParameter::new(Self::PARAMETER_NB, self.into().get_raw(Self::RANGE))
+    }
+}
+
+/// A `DiscreteParameter`, view as a CC `Parameter`, e.g. part of received as MIDI `CC` message.
+pub trait DiscreteCCParameter: DiscreteParameter {
+    const CC_NB: CCNumber;
+
+    fn from_cc(cc_val: CCValue) -> Self {
+        DiscreteValue::new(cc_val.into(), Self::RANGE).into()
+    }
+
+    fn to_cc(self) -> CC {
+        CC::new(Self::CC_NB, self.into().normal().into())
+    }
+}
+
+macro_rules! discrete_parameter {
+    ($param:ident {
+        const DEFAULT = $default:expr,
+        const MIN_RAW = $min:expr,
+        const MAX_RAW = $max:expr $(,)?
+    } ) => {
+        #[derive(Clone, Copy, Debug)]
+        pub struct $param(crate::jstation::data::DiscreteValue);
+
+        impl From<crate::jstation::data::DiscreteValue> for $param {
+            fn from(value: crate::jstation::data::DiscreteValue) -> Self {
+                $param(value)
+            }
+        }
+
+        impl From<$param> for crate::jstation::data::DiscreteValue {
+            fn from(value: $param) -> Self {
+                value.0
+            }
+        }
+
+        impl crate::jstation::data::DiscreteParameter for $param {
+            const DEFAULT: crate::jstation::data::Normal = $default;
+            const MIN_RAW: crate::jstation::data::RawValue = $min;
+            const MAX_RAW: crate::jstation::data::RawValue = $max;
+            const RANGE: crate::jstation::data::DiscreteRange =
+                crate::jstation::data::DiscreteRange::new(Self::MIN_RAW, Self::MAX_RAW);
+        }
+    };
+
+    ($param:ident {
+        const DEFAULT = $default:expr,
+        const MAX_RAW = $max:expr $(,)?
+    } ) => {
+        discrete_parameter!($param {
+            const DEFAULT = $default,
+            const MIN_RAW = crate::jstation::data::RawValue::ZERO,
+            const MAX_RAW = $max,
+        });
+    };
+
+    ( $param:ident {
+        const DEFAULT = $default:expr,
+        const MIN_RAW = $min:expr,
+        const MAX_RAW = $max:expr,
+        const PARAMETER_NB = $param_nb:expr $(,)?
+    } ) => {
+        discrete_parameter!($param {
+            const DEFAULT = $default,
+            const MIN_RAW = $min,
+            const MAX_RAW = $max,
+        });
+
+        impl crate::jstation::data::DiscreteRawParameter for $param {
+            const PARAMETER_NB: crate::jstation::data::ParameterNumber = $param_nb;
+        }
+    };
+
+    ( $param:ident {
+        const DEFAULT = $default:expr,
+        const MAX_RAW = $max:expr,
+        const PARAMETER_NB = $param_nb:expr $(,)?
+    } ) => {
+        discrete_parameter!($param {
+            const DEFAULT = $default,
+            const MIN_RAW = crate::jstation::data::RawValue::ZERO,
+            const MAX_RAW = $max,
+            const PARAMETER_NB = $param_nb,
+        });
+    };
+
+    ( $param:ident {
+        const DEFAULT = $default:expr,
+        const MIN_RAW = $min:expr,
+        const MAX_RAW = $max:expr,
+        const CC_NB = $cc_nb:expr $(,)?
+    } ) => {
+        discrete_parameter!($param {
+            const DEFAULT = $default,
+            const MIN_RAW = $min,
+            const MAX_RAW = $max
+        });
+
+        impl crate::jstation::data::DiscreteCCParameter for $param {
+            const CC_NB: crate::midi::CCNumber = $cc_nb;
+        }
+    };
+
+    ( $param:ident {
+        const DEFAULT = $default:expr,
+        const MAX_RAW = $max:expr,
+        const CC_NB = $cc_nb:expr $(,)?
+    } ) => {
+        discrete_parameter!($param {
+            const DEFAULT = $default,
+            const MIN_RAW = crate::jstation::data::RawValue::ZERO,
+            const MAX_RAW = $max,
+            const CC_NB = $cc_nb,
+        });
+    };
+
+    ( $param:ident {
+        const DEFAULT = $default:expr,
+        const MIN_RAW = $min:expr,
+        const MAX_RAW = $max:expr,
+        const PARAMETER_NB = $param_nb:expr,
+        const CC_NB = $cc_nb:expr $(,)?
+    } ) => {
+        discrete_parameter!($param {
+            const DEFAULT = $default,
+            const MIN_RAW = $min,
+            const MAX_RAW = $max,
+            const PARAMETER_NB = $param_nb,
+        });
+
+        impl crate::jstation::data::DiscreteCCParameter for $param {
+            const CC_NB: crate::jstation::midi::CCNumber = $cc_nb;
+        }
+    };
+
+    ( $param:ident {
+        const DEFAULT = $default:expr,
+        const MAX_RAW = $max:expr,
+        const PARAMETER_NB = $param_nb:expr,
+        const CC_NB = $cc_nb:expr $(,)?
+    } ) => {
+        discrete_parameter!($param {
+            const DEFAULT = $default,
+            const MIN_RAW = crate::jstation::data::RawValue::ZERO,
+            const MAX_RAW = $max,
+            const PARAMETER_NB = $param_nb,
+            const CC_NB = $cc_nb,
+        });
+    };
+}
+
+// A discrete value which is guaranteed to be snapped to the provided [`DiscreteRange`].
+#[derive(Copy, Clone, Debug)]
+pub struct DiscreteValue {
+    normal: Normal,
+}
+
+impl DiscreteValue {
+    pub fn new(normal: Normal, range: DiscreteRange) -> Self {
+        DiscreteValue {
+            normal: range.snap(normal),
+        }
+    }
+
+    pub fn try_from_raw(raw: RawValue, range: DiscreteRange) -> Result<Self, Error> {
+        let normal = range.try_normalize(raw)?;
+
+        Ok(DiscreteValue { normal })
+    }
+
+    pub fn normal(self) -> Normal {
+        self.normal
+    }
+
+    pub fn get_raw(&self, range: DiscreteRange) -> RawValue {
+        ((self.normal.as_f32() * range.zero_based_max) as u8 + range.min).into()
+    }
+}
+
+/// An inclusive `DiscreteRange` of discrete [`Value`]s between 0 and `max`.
+///
+/// [`Value`]: ../raw/struct.Value.html
+#[derive(Clone, Copy, Debug)]
+pub struct DiscreteRange {
+    min: u8,
+    zero_based_max: f32,
+    // Note: in a previous implementation, I used a `max_recip` to avoid float divisions
+    // in some functions, thus allegedly saving a few cycles. However, since float operations
+    // can't be used in `const` functions, I had to use a `once_cell` in the parameters and
+    // return the `DiscreteRange` lazily, which adds some cycles too and cache misses potentialy.
+    // I ended up deciding it wasn't worth the complexity.
+}
+
+impl DiscreteRange {
+    /// Builds a new `DiscreteRange` from the provided value.
+    ///
+    /// # Panic
+    ///
+    /// Panics if `min` < `max`.
+    pub const fn new(min: RawValue, max: RawValue) -> Self {
+        let min = min.as_u8();
+        let max = max.as_u8();
+
+        assert!(min < max);
+
+        DiscreteRange {
+            min,
+            zero_based_max: (max - min) as f32,
+        }
+    }
+
+    fn out_of_range_error(self, value: RawValue) -> Error {
+        Error::ParameterRawValueOutOfRange {
+            value,
+            min: self.min.into(),
+            max: (self.zero_based_max as u8 + self.min).into(),
+        }
+    }
+
+    /// Tries to build a `Normal` from the provided `value`.
+    fn try_normalize(self, value: RawValue) -> Result<Normal, Error> {
+        let zero_based_value = value
+            .as_u8()
+            .checked_sub(self.min)
+            .ok_or_else(|| self.out_of_range_error(value))? as f32;
+
+        let normal = Normal::try_from(zero_based_value / self.zero_based_max)
+            .map_err(|_| self.out_of_range_error(value))?;
+
+        Ok(self.snap(normal))
+    }
+
+    /// Returns the provided `Normal` after snapping it to this `DiscreteRange`.
+    pub fn snap(&self, normal: Normal) -> Normal {
+        unsafe {
+            // Safety: `self.zero_based_max` is ensured to be a positive integral since
+            // the only way to build `DiscreteRange` is via `DiscreteRange::new` which uses
+            // a `RawValue` which is guaranteed to be built from an `u8`.
+            //
+            // The expression `normal_snapped` is expected to be in the range `(0.0..=1.0)`,
+            // thanks to the `(0.0..=1.0)` guarantee for `normal`.
+            // `(normal.as_f32() * self.zero_based_max).round()` equals at most
+            // `self.zero_based_max`, so `normal_snapped` can't be greater than `1.0`.
+
+            let normal_snapped =
+                (normal.as_f32() * self.zero_based_max).round() / self.zero_based_max;
+            Normal::new_unchecked(normal_snapped)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DiscreteRange, DiscreteValue, Error, Normal, RawValue};
+
+    #[test]
+    fn range_round_trip_min_zero() {
+        const MAX: RawValue = RawValue::new(24);
+        const HALF: RawValue = RawValue::new(MAX.as_u8() / 2);
+        const BEYOND_MAX: RawValue = RawValue::new(MAX.as_u8() + 1);
+
+        let range = DiscreteRange::new(RawValue::ZERO, MAX);
+
+        let normal = range.try_normalize(RawValue::ZERO).unwrap();
+        assert_eq!(normal.as_f32(), 0.0);
+        assert_eq!(DiscreteValue { normal }.get_raw(range), RawValue::ZERO);
+
+        let normal = range.try_normalize(HALF).unwrap();
+        assert_eq!(normal.as_f32(), 0.5);
+        assert_eq!(DiscreteValue { normal }.get_raw(range), HALF);
+
+        let normal = range.try_normalize(MAX).unwrap();
+        assert_eq!(normal.as_f32(), 1.0);
+        assert_eq!(DiscreteValue { normal }.get_raw(range), MAX);
+
+        let res = range.try_normalize(BEYOND_MAX);
+        if let Error::ParameterRawValueOutOfRange { value, min, max } = res.unwrap_err() {
+            assert_eq!(value, BEYOND_MAX);
+            assert_eq!(min, RawValue::ZERO);
+            assert_eq!(max, MAX);
+        }
+    }
+
+    #[test]
+    fn range_round_trip_min_one() {
+        const MIN: RawValue = RawValue::new(1);
+        const MAX: RawValue = RawValue::new(25);
+        const HALF: RawValue = RawValue::new((MAX.as_u8() + MIN.as_u8()) / 2);
+        const BEYOND_MAX: RawValue = RawValue::new(MAX.as_u8() + 1);
+
+        let range = DiscreteRange::new(MIN, MAX);
+
+        let normal = range.try_normalize(MIN).unwrap();
+        assert_eq!(normal.as_f32(), 0.0);
+        assert_eq!(DiscreteValue { normal }.get_raw(range), MIN);
+
+        let normal = range.try_normalize(HALF).unwrap();
+        assert_eq!(normal.as_f32(), 0.5);
+        assert_eq!(DiscreteValue { normal }.get_raw(range), HALF);
+
+        let normal = range.try_normalize(MAX).unwrap();
+        assert_eq!(normal.as_f32(), 1.0);
+        assert_eq!(DiscreteValue { normal }.get_raw(range), MAX);
+
+        let res = range.try_normalize(RawValue::ZERO);
+        if let Error::ParameterRawValueOutOfRange { value, min, max } = res.unwrap_err() {
+            assert_eq!(value, RawValue::ZERO);
+            assert_eq!(min, MIN);
+            assert_eq!(max, MAX);
+        }
+
+        let res = range.try_normalize(BEYOND_MAX);
+        if let Error::ParameterRawValueOutOfRange { value, min, max } = res.unwrap_err() {
+            assert_eq!(value, BEYOND_MAX);
+            assert_eq!(min, MIN);
+            assert_eq!(max, MAX);
+        }
+    }
+
+    #[test]
+    fn snap() {
+        let r23 = DiscreteRange::new(RawValue::ZERO, 23.into());
+        let r24 = DiscreteRange::new(RawValue::ZERO, 24.into());
+        let r25 = DiscreteRange::new(RawValue::ZERO, 25.into());
+
+        assert_eq!(r23.snap(Normal::HALF).as_f32() * 23.0, 12.0);
+        assert_eq!(r24.snap(Normal::HALF).as_f32() * 24.0, 12.0);
+        assert_eq!(r25.snap(Normal::HALF).as_f32() * 25.0, 13.0);
+
+        let normal_third = Normal::try_from(1.0 / 3.0).unwrap();
+        assert_eq!(r23.snap(normal_third).as_f32() * 23.0, 8.0);
+        assert_eq!(r24.snap(normal_third).as_f32() * 24.0, 8.0);
+        assert_eq!(r25.snap(normal_third).as_f32() * 25.0, 8.0);
+
+        assert_eq!(r24.snap(Normal::MAX).as_f32() * 24.0, 24.0);
+        assert_eq!(r25.snap(Normal::MAX).as_f32() * 25.0, 25.0);
+    }
+}

--- a/src/jstation/data/parameter/mod.rs
+++ b/src/jstation/data/parameter/mod.rs
@@ -1,0 +1,88 @@
+#[macro_use]
+mod boolean;
+pub use boolean::{BoolCCParameter, BoolParameter, BoolRawParameter};
+
+#[macro_use]
+mod discrete;
+pub use discrete::{
+    DiscreteCCParameter, DiscreteParameter, DiscreteRange, DiscreteRawParameter, DiscreteValue,
+};
+
+mod normal;
+pub use normal::Normal;
+
+mod raw;
+pub use raw::{RawParameter, RawValue};
+
+use std::fmt;
+
+use crate::jstation::Error;
+
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+pub struct ParameterNumber(u8);
+
+impl ParameterNumber {
+    pub const MAX: ParameterNumber = ParameterNumber(43);
+
+    pub const fn new(nb: u8) -> Self {
+        ParameterNumber(nb)
+    }
+
+    pub const fn as_u8(self) -> u8 {
+        self.0
+    }
+}
+
+impl TryFrom<u8> for ParameterNumber {
+    type Error = Error;
+
+    fn try_from(nb: u8) -> Result<Self, Error> {
+        if nb > Self::MAX.0 {
+            return Err(Error::ParameterNumberOutOfRange(nb));
+        }
+
+        Ok(ParameterNumber(nb))
+    }
+}
+
+// FIXME should probably be faillible
+impl From<ParameterNumber> for u8 {
+    fn from(nb: ParameterNumber) -> Self {
+        nb.0
+    }
+}
+
+impl fmt::Display for ParameterNumber {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&(self.0 + 1), f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Error, ParameterNumber};
+
+    #[test]
+    fn parameter_number() {
+        assert_eq!(
+            ParameterNumber::try_from(ParameterNumber::MAX.0 - 1).unwrap(),
+            ParameterNumber(ParameterNumber::MAX.0 - 1),
+        );
+
+        assert_eq!(
+            ParameterNumber::try_from(ParameterNumber::MAX.0).unwrap(),
+            ParameterNumber(ParameterNumber::MAX.0),
+        );
+
+        if let Error::ParameterNumberOutOfRange(nb) =
+            ParameterNumber::try_from(ParameterNumber::MAX.0 + 1).unwrap_err()
+        {
+            assert_eq!(nb, ParameterNumber::MAX.0 + 1)
+        }
+
+        let res = ParameterNumber::try_from(0xff);
+        if let Error::ParameterNumberOutOfRange(nb) = res.unwrap_err() {
+            assert_eq!(nb, 0xff)
+        }
+    }
+}

--- a/src/jstation/data/parameter/normal.rs
+++ b/src/jstation/data/parameter/normal.rs
@@ -1,0 +1,91 @@
+use crate::{jstation::Error, midi::CCValue};
+
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+pub struct Normal(f32);
+
+impl Normal {
+    pub const MIN: Normal = Normal(0.0);
+    pub const HALF: Normal = Normal(0.5);
+    pub const MAX: Normal = Normal(1.0);
+
+    const MAX_CC_VALUE: f32 = CCValue::MAX.as_u8() as f32;
+
+    pub const fn as_f32(self) -> f32 {
+        self.0
+    }
+
+    pub fn into_cc_value(self) -> CCValue {
+        // FIXME we could impl `CCValue::new_unchecked` instead.
+        CCValue::new_clipped((self.0 * Self::MAX_CC_VALUE) as u8)
+    }
+
+    /// Builds a `Normal` from the provided value, whithout checking it.
+    ///
+    /// # Safety
+    ///
+    /// The value must be in the range `(0.0..=1.0)`.
+    pub unsafe fn new_unchecked(normal: f32) -> Self {
+        Normal(normal)
+    }
+}
+
+impl From<Normal> for CCValue {
+    fn from(normal: Normal) -> Self {
+        normal.into_cc_value()
+    }
+}
+
+impl From<CCValue> for Normal {
+    fn from(value: CCValue) -> Self {
+        Normal(value.as_u8() as f32 / Normal::MAX_CC_VALUE)
+    }
+}
+
+impl From<Normal> for f32 {
+    fn from(normal: Normal) -> Self {
+        normal.0
+    }
+}
+
+impl TryFrom<f32> for Normal {
+    type Error = Error;
+
+    fn try_from(value: f32) -> Result<Self, Self::Error> {
+        if !(0.0..=1.0).contains(&value) {
+            return Err(Error::NormalOutOfRange(value));
+        }
+
+        Ok(Normal(value))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CCValue, Error, Normal};
+
+    #[test]
+    fn normal() {
+        assert_eq!(Normal::try_from(0.0).unwrap(), Normal::MIN);
+        assert_eq!(Normal::try_from(0.5).unwrap(), Normal::HALF);
+        assert_eq!(Normal::try_from(1.0).unwrap(), Normal::MAX);
+
+        match Normal::try_from(Normal::MIN.0 - 0.1).unwrap_err() {
+            Error::NormalOutOfRange(val) => assert_eq!(val, Normal::MIN.0 - 0.1),
+            other => panic!("{other}"),
+        }
+
+        match Normal::try_from(Normal::MAX.0 + 0.1).unwrap_err() {
+            Error::NormalOutOfRange(val) => assert_eq!(val, Normal::MAX.0 + 0.1),
+            other => panic!("{other}"),
+        }
+    }
+
+    #[test]
+    fn cc_value() {
+        assert_eq!(CCValue::from(Normal::MIN), CCValue::ZERO);
+        assert_eq!(CCValue::from(Normal::MAX), CCValue::MAX);
+
+        assert_eq!(Normal::from(CCValue::ZERO), Normal::MIN);
+        assert_eq!(Normal::from(CCValue::MAX), Normal::MAX);
+    }
+}

--- a/src/jstation/data/parameter/raw.rs
+++ b/src/jstation/data/parameter/raw.rs
@@ -1,0 +1,64 @@
+use std::fmt;
+
+use crate::jstation::data::ParameterNumber;
+
+#[derive(Copy, Clone, Debug)]
+pub struct RawParameter {
+    nb: ParameterNumber,
+    value: RawValue,
+}
+
+impl RawParameter {
+    pub fn new(nb: ParameterNumber, value: RawValue) -> Self {
+        RawParameter { nb, value }
+    }
+
+    pub fn nb(self) -> ParameterNumber {
+        self.nb
+    }
+
+    pub fn value(self) -> RawValue {
+        self.value
+    }
+}
+
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd)]
+pub struct RawValue(u8);
+
+impl RawValue {
+    pub const ZERO: Self = RawValue(0);
+    pub const HALF: Self = RawValue(0x7f);
+    pub const MAX: Self = RawValue(0xff);
+
+    pub const fn new(value: u8) -> Self {
+        RawValue(value)
+    }
+
+    pub const fn as_u8(self) -> u8 {
+        self.0
+    }
+}
+
+impl From<u8> for RawValue {
+    fn from(value: u8) -> Self {
+        Self(value)
+    }
+}
+
+impl From<RawValue> for u8 {
+    fn from(value: RawValue) -> Self {
+        value.0
+    }
+}
+
+impl From<&RawValue> for u8 {
+    fn from(value: &RawValue) -> Self {
+        value.0
+    }
+}
+
+impl fmt::Display for RawValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}

--- a/src/jstation/error.rs
+++ b/src/jstation/error.rs
@@ -1,0 +1,69 @@
+use std::sync::Arc;
+
+use crate::{jstation::data::RawValue, midi};
+
+#[derive(Clone, Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Unknown J-Station CC number x{:02x}", .0)]
+    CCNumber(u8),
+
+    #[error("Parameter number {} out of range", .0)]
+    ParameterNumberOutOfRange(u8),
+
+    #[error("Parameter raw value {} out of range: ({}..={})", .value, .min, .max)]
+    ParameterRawValueOutOfRange {
+        value: RawValue,
+        min: RawValue,
+        max: RawValue,
+    },
+
+    #[error("Program number {} out of range", .0)]
+    ProgramNumberOutOfRange(u8),
+
+    #[error("Program data size {} out of range", .0)]
+    ProgramDataOutOfRange(usize),
+
+    #[error("Program name size {} out of range", .0)]
+    ProgramNameOutOfRange(usize),
+
+    #[error("Error Parsing MIDI message")]
+    Parse,
+
+    #[error("{}", .0)]
+    Midi(#[from] midi::Error),
+
+    #[error("No MIDI connection")]
+    MidiNotConnected,
+
+    #[error("An error occured sending a MIDI message")]
+    MidiSend,
+
+    #[error("Normal out of range: {}", .0)]
+    NormalOutOfRange(f32),
+
+    #[error("Device handshake timed out")]
+    HandshakeTimeout,
+
+    #[error("{}: {}", ctx, source)]
+    WithContext {
+        ctx: Arc<str>,
+        source: Arc<dyn std::error::Error + Send + Sync>,
+    },
+}
+
+impl Error {
+    // FIXME there must be a better way...
+    pub fn with_context<E>(ctx: &'static str, source: E) -> Self
+    where
+        E: 'static + std::error::Error + Send + Sync,
+    {
+        Error::WithContext {
+            ctx: Arc::from(ctx),
+            source: Arc::new(source),
+        }
+    }
+
+    pub fn is_handshake_timeout(&self) -> bool {
+        matches!(self, Error::HandshakeTimeout)
+    }
+}

--- a/src/jstation/interface.rs
+++ b/src/jstation/interface.rs
@@ -1,49 +1,13 @@
 use std::sync::Arc;
 
 use crate::{
-    jstation::{parse_raw_midi_msg, procedure, sysex, Message, Procedure, ProcedureBuilder},
+    jstation::{parse_raw_midi_msg, procedure, sysex, Error, Message, Procedure, ProcedureBuilder},
     midi,
 };
 
 use std::time::Duration;
 
 const HANDSHAKE_TIMEOUT: Duration = Duration::from_millis(200);
-
-#[derive(Clone, Debug, thiserror::Error)]
-pub enum Error {
-    #[error("Error Parsing MIDI message")]
-    Parse,
-    #[error("{}", .0)]
-    Midi(#[from] midi::Error),
-    #[error("No MIDI connection")]
-    MidiNotConnected,
-    #[error("An error occured sending a MIDI message")]
-    MidiSend,
-    #[error("Device handshake timed out")]
-    HandshakeTimeout,
-    #[error("{}: {}", ctx, source)]
-    WithContext {
-        ctx: Arc<str>,
-        source: Arc<dyn std::error::Error + Send + Sync>,
-    },
-}
-
-impl Error {
-    // FIXME there must be a better way...
-    pub fn with_context<E>(ctx: &'static str, source: E) -> Self
-    where
-        E: 'static + std::error::Error + Send + Sync,
-    {
-        Error::WithContext {
-            ctx: Arc::from(ctx),
-            source: Arc::new(source),
-        }
-    }
-
-    pub fn is_handshake_timeout(&self) -> bool {
-        matches!(self, Error::HandshakeTimeout)
-    }
-}
 
 pub struct Interface {
     pub ins: midi::PortsIn,

--- a/src/midi/channel_voice/cc.rs
+++ b/src/midi/channel_voice/cc.rs
@@ -1,81 +1,173 @@
-use nom::{
-    bytes::complete::take,
-    error::{self, Error},
-    IResult,
-};
+use nom::{bytes::complete::take, IResult};
+
+use std::fmt;
 
 use crate::midi;
 
 #[derive(Copy, Clone, Debug)]
 pub struct CC {
-    pub param: Parameter,
-    pub value: Value,
+    pub nb: CCNumber,
+    pub value: CCValue,
 }
 
 impl CC {
     pub const TAG: midi::Tag = midi::Tag(0xb0);
+
+    pub fn new(nb: CCNumber, value: CCValue) -> Self {
+        CC { nb, value }
+    }
 }
 
 pub fn parse(i: &[u8]) -> IResult<&[u8], CC> {
-    let (i, param) = take(1usize)(i)?;
-    let param = Parameter::try_from(param[0]).map_err(|err| {
+    use nom::error::{self, Error};
+
+    let (i, nb) = take(1usize)(i)?;
+    let nb = CCNumber::try_from(nb[0]).map_err(|err| {
         log::error!("CC: {err}");
 
         nom::Err::Failure(Error::new(i, error::ErrorKind::Verify))
     })?;
 
     let (i, value) = take(1usize)(i)?;
-    let value = Value::try_from(value[0]).map_err(|err| {
+    let value = CCValue::try_from(value[0]).map_err(|err| {
         log::error!("CC: {err}");
 
         nom::Err::Failure(Error::new(i, error::ErrorKind::Verify))
     })?;
 
-    Ok((i, CC { param, value }))
+    Ok((i, CC { nb, value }))
 }
 
-#[derive(Debug, thiserror::Error)]
-pub enum CCError {
-    #[error("J-Station CC parameter out of range 0x{:02x}", .0)]
-    ParameterOutOfRange(u8),
-    #[error("J-Station CC value out of range 0x{:02x}", .0)]
+#[derive(Debug, Eq, PartialEq, thiserror::Error)]
+#[allow(clippy::enum_variant_names)]
+pub enum Error {
+    #[error("CC number out of range 0x{:02x}", .0)]
+    NumberOutOfRange(u8),
+    #[error("CC value out of range 0x{:02x}", .0)]
     ValueOutOfRange(u8),
 }
 
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
-pub struct Parameter(u8);
+pub struct CCNumber(u8);
 
-impl Parameter {
-    pub const MAX: Parameter = Parameter(0x77);
+impl CCNumber {
+    pub const MAX: CCNumber = CCNumber(0x77);
+
+    /// Builds a new CC `CCNumber`.
+    ///
+    /// # Panic
+    ///
+    /// Panics if the provided number is larger than `CCNumber::MAX`.
+    pub const fn new(nb: u8) -> Self {
+        assert!(nb <= Self::MAX.0);
+
+        CCNumber(nb)
+    }
+
+    pub const fn as_u8(self) -> u8 {
+        self.0
+    }
 }
 
-impl TryFrom<u8> for Parameter {
-    type Error = CCError;
+impl TryFrom<u8> for CCNumber {
+    type Error = Error;
 
-    fn try_from(param: u8) -> Result<Self, Self::Error> {
-        if param > Self::MAX.0 {
-            return Err(CCError::ParameterOutOfRange(param));
+    fn try_from(nb: u8) -> Result<Self, Self::Error> {
+        if nb > Self::MAX.0 {
+            return Err(Error::NumberOutOfRange(nb));
         }
 
-        Ok(Self(param))
+        Ok(Self(nb))
+    }
+}
+
+impl From<CCNumber> for u8 {
+    fn from(nb: CCNumber) -> Self {
+        nb.0
+    }
+}
+
+impl fmt::Display for CCNumber {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
     }
 }
 
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
-pub struct Value(u8);
+pub struct CCValue(u8);
 
-impl Value {
-    pub const MAX: Value = Value(0x7f);
+impl CCValue {
+    pub const ZERO: CCValue = CCValue(0);
+    pub const MAX: CCValue = CCValue(0x7f);
+
+    pub const fn new_clipped(value: u8) -> Self {
+        CCValue(if value > Self::MAX.0 {
+            Self::MAX.0
+        } else {
+            value
+        })
+    }
+
+    pub const fn as_u8(self) -> u8 {
+        self.0
+    }
 }
 
-impl TryFrom<u8> for Value {
-    type Error = CCError;
+impl TryFrom<u8> for CCValue {
+    type Error = Error;
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         if value > Self::MAX.0 {
-            return Err(CCError::ValueOutOfRange(value));
+            return Err(Error::ValueOutOfRange(value));
         }
 
         Ok(Self(value))
+    }
+}
+
+impl From<CCValue> for u8 {
+    fn from(value: CCValue) -> Self {
+        value.0
+    }
+}
+
+impl From<&CCValue> for u8 {
+    fn from(value: &CCValue) -> Self {
+        value.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CCNumber, CCValue, Error};
+
+    #[test]
+    fn parameter_number() {
+        assert_eq!(
+            CCNumber::try_from(CCNumber::MAX.0 - 1),
+            Ok(CCNumber(CCNumber::MAX.0 - 1))
+        );
+        assert_eq!(CCNumber::try_from(CCNumber::MAX.0), Ok(CCNumber::MAX));
+
+        assert_eq!(
+            CCNumber::try_from(CCNumber::MAX.0 + 1),
+            Err(Error::NumberOutOfRange(CCNumber::MAX.0 + 1))
+        );
+        assert_eq!(CCNumber::try_from(0xff), Err(Error::NumberOutOfRange(0xff)));
+    }
+
+    #[test]
+    fn value() {
+        assert_eq!(
+            CCValue::try_from(CCValue::MAX.0 - 1),
+            Ok(CCValue(CCValue::MAX.0 - 1))
+        );
+        assert_eq!(CCValue::try_from(CCValue::MAX.0), Ok(CCValue::MAX));
+
+        assert_eq!(
+            CCValue::try_from(CCValue::MAX.0 + 1),
+            Err(Error::ValueOutOfRange(CCValue::MAX.0 + 1))
+        );
+        assert_eq!(CCValue::try_from(0xff), Err(Error::ValueOutOfRange(0xff)));
     }
 }

--- a/src/midi/channel_voice/mod.rs
+++ b/src/midi/channel_voice/mod.rs
@@ -5,7 +5,7 @@ use nom::{
 };
 
 pub mod cc;
-pub use cc::CC;
+pub use cc::{CCNumber, CCValue, CC};
 
 use crate::midi;
 
@@ -18,7 +18,6 @@ pub struct ChannelVoice {
 #[derive(Copy, Clone, Debug)]
 pub enum Message {
     CC(CC),
-    // FIXME check range / use specific type
     ProgramChange(u8),
 }
 
@@ -36,7 +35,7 @@ pub fn parse(i: &[u8]) -> IResult<&[u8], ChannelVoice> {
         other => {
             log::warn!(
                 "Unknown Midi ChannelVoice tag with id: 0x{:02x}",
-                u8::from(other),
+                other.as_u8(),
             );
             return Err(nom::Err::Failure(Error::new(i, error::ErrorKind::NoneOf)));
         }

--- a/src/midi/error.rs
+++ b/src/midi/error.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-#[derive(Clone, Debug, thiserror::Error)]
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
 pub enum Error {
     #[error("MIDI initialization failed")]
     Init(#[from] midir::InitError),
@@ -25,12 +25,6 @@ pub enum Error {
 
     #[error("MIDI port refresh discarded while scanning")]
     ScanningPorts,
-
-    #[error("Invalid normalized u14: {}", .0)]
-    InvalidU14(u16),
-
-    #[error("Invalid normalized float: {}", .0)]
-    InvalidNormalizedFloat(f64),
 
     #[error("Couldn't send MIDI message: {}", .0)]
     Send(#[from] midir::SendError),

--- a/src/midi/mod.rs
+++ b/src/midi/mod.rs
@@ -1,5 +1,5 @@
 pub mod channel_voice;
-pub use channel_voice::{ChannelVoice, CC};
+pub use channel_voice::{CCNumber, CCValue, ChannelVoice, CC};
 
 mod error;
 pub use error::Error;
@@ -14,6 +14,12 @@ use std::fmt;
 
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
 pub struct Tag(u8);
+
+impl Tag {
+    pub fn as_u8(self) -> u8 {
+        self.0
+    }
+}
 
 impl From<Tag> for u8 {
     fn from(tag: Tag) -> Self {
@@ -32,6 +38,10 @@ pub struct Channel(u8);
 
 impl Channel {
     pub const ALL: Self = Channel(0x7e);
+
+    pub fn as_u8(self) -> u8 {
+        self.0
+    }
 }
 
 impl From<u8> for Channel {

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -98,7 +98,19 @@ impl App {
                 }
             }
             Ok(ChannelVoice(cv)) => {
-                log::info!("Unhandled {:?}", cv.msg);
+                use jstation::channel_voice::Message::*;
+                match cv.msg {
+                    CC(cc) => {
+                        use jstation::CCParameter::*;
+                        match cc {
+                            Gain(gain) => log::info!("Got {gain:?}"),
+                            other => log::info!("Unhandled cc {other:?}"),
+                        }
+                    }
+                    ProgramChange(pc) => {
+                        log::info!("Unhandled {pc:?}");
+                    }
+                }
             }
             Err(err) if err.is_handshake_timeout() => {
                 if let Some(scanner_ctx) = self.scanner_ctx.take() {
@@ -113,7 +125,14 @@ impl App {
                     return Err(Error::JStationNotFound);
                 }
             }
-            Err(err) => Err(err)?,
+            Err(err) => {
+                // Switch to true to panic on first error
+                if false {
+                    panic!("{err}");
+                } else {
+                    Err(err)?;
+                }
+            }
         }
 
         Ok(())

--- a/src/ui/utility_settings.rs
+++ b/src/ui/utility_settings.rs
@@ -36,7 +36,7 @@ impl From<UtilitySettingsResp> for Settings {
             global_cabinet: val.global_cabinet,
             midi_merge: val.midi_merge,
             midi_channel: MIDI_CHANNEL_RANGE
-                .normal_param(u8::from(val.midi_channel) as i32, DEFAULT_MIDI_CHANNEL),
+                .normal_param(val.midi_channel.as_u8() as i32, DEFAULT_MIDI_CHANNEL),
         }
     }
 }


### PR DESCRIPTION
Program parameters represent a parameter of the device. They can be obtained as `RawParameter` (coming from a Program related procedure) or from a CC event. They come in two flavors:

- `DiscreteParameter`s encode a value and a range. They are   characterized by their default value and Parameter & CC numbers. The value is internally implemented as a `Normal` value, making it esay to convert to a CC value or UI widget value.
- `BoolParameter`s encode a boolean value. They also are characterized by their default value and Parameter & CC numbers.

The `discrete_parameter` and `bool_parameter` macros allow easily define parameters from their characteristics and auto-generate the resulting `struct` and implementations.

Tested with all parameters from the amp and noise gap dsp, changing the parameters from the device and checking the appropriate events were received from the application with the expected values.