### PR TITLE
Jstation derive cleanups

### DIFF
--- a/jstation_derive/src/lib.rs
+++ b/jstation_derive/src/lib.rs
@@ -16,7 +16,7 @@ pub(crate) use param::Param;
 
 mod param_group;
 
-#[proc_macro_derive(ParameterGroup, attributes(boolean, const_range, variable_range))]
+#[proc_macro_derive(ParameterSetter, attributes(boolean, const_range, variable_range))]
 #[proc_macro_error]
 pub fn param_group(input: TokenStream) -> TokenStream {
     let input: DeriveInput = parse_macro_input!(input);

--- a/jstation_derive/src/param.rs
+++ b/jstation_derive/src/param.rs
@@ -1,15 +1,17 @@
+use heck::ToTitleCase;
 use proc_macro2::TokenStream;
-use proc_macro_error::abort;
+use proc_macro_error::{abort, ResultExt};
 use quote::ToTokens;
 use syn::{
     self,
     parse::{Parse, ParseStream},
+    punctuated::Punctuated,
     Expr, Field, Ident, Token, Type,
 };
 
 use crate::{Boolean, ConstRange, VariableRange};
 
-pub enum Param<'a> {
+pub(crate) enum Param<'a> {
     ConstRange(ConstRange<'a>),
     Boolean(Boolean<'a>),
     VariableRange(VariableRange<'a>),
@@ -30,46 +32,48 @@ impl<'a> Param<'a> {
             );
         }
 
-        let param = if field.attrs[0].path.is_ident("const_range") {
-            Param::ConstRange(ConstRange::from_attrs(field, &field.attrs[0]))
-        } else if field.attrs[0].path.is_ident("boolean") {
-            Param::Boolean(Boolean::from_attrs(field, &field.attrs[0]))
-        } else if field.attrs[0].path.is_ident("variable_range") {
-            Param::VariableRange(VariableRange::from_attrs(field, &field.attrs[0]))
+        let attr = &field.attrs[0];
+        let args = attr
+            .parse_args_with(Punctuated::<Arg, Token![,]>::parse_terminated)
+            .unwrap_or_abort()
+            .into_iter();
+
+        let param = ParamBase::new(field);
+
+        if attr.path.is_ident("const_range") {
+            Some(Param::ConstRange(ConstRange::new(param, args)))
+        } else if attr.path.is_ident("boolean") {
+            Some(Param::Boolean(Boolean::new(param, args)))
+        } else if attr.path.is_ident("variable_range") {
+            Some(Param::VariableRange(VariableRange::new(param, args)))
         } else {
             abort!(
                 field,
                 "Unknown param attribute {} for {}",
-                field.attrs[0].path.to_token_stream(),
-                field.ty.to_token_stream(),
+                attr.path.to_token_stream(),
+                param.field.ty.to_token_stream(),
             );
-        };
-
-        Some(param)
+        }
     }
 
-    pub fn typ(&self) -> &Type {
+    fn base(&self) -> &ParamBase {
         match self {
-            Param::ConstRange(param) => param.typ(),
-            Param::Boolean(param) => param.typ(),
-            Param::VariableRange(param) => param.typ(),
+            Param::ConstRange(param) => &param.base,
+            Param::Boolean(param) => &param.base,
+            Param::VariableRange(param) => &param.base,
         }
+    }
+
+    pub fn ty(&self) -> &Type {
+        &self.base().field.ty
     }
 
     pub fn field(&self) -> &Ident {
-        match self {
-            Param::ConstRange(param) => param.field(),
-            Param::Boolean(param) => param.field(),
-            Param::VariableRange(param) => param.field(),
-        }
+        self.base().field.ident.as_ref().expect("named field")
     }
 
     pub fn cc_nb(&self) -> Option<u8> {
-        match self {
-            Param::ConstRange(param) => param.cc_nb(),
-            Param::Boolean(param) => param.cc_nb(),
-            Param::VariableRange(param) => param.cc_nb(),
-        }
+        self.base().cc_nb
     }
 
     pub fn is_discriminant(&self) -> bool {
@@ -78,9 +82,41 @@ impl<'a> Param<'a> {
             _ => false,
         }
     }
+}
 
-    pub fn is_variable_range(&self) -> bool {
-        matches!(self, Param::VariableRange(_))
+pub struct ParamBase<'a> {
+    pub field: &'a Field,
+    pub param_nb: Option<u8>,
+    pub cc_nb: Option<u8>,
+}
+
+impl<'a> ParamBase<'a> {
+    pub fn new(field: &'a Field) -> Self {
+        ParamBase {
+            field,
+            param_nb: None,
+            cc_nb: None,
+        }
+    }
+
+    pub fn have_arg(&mut self, arg: Arg) {
+        let name = arg.name.to_string();
+        match name.as_str() {
+            "param_nb" => self.param_nb = Some(arg.u8_or_abort(self.field)),
+            "cc_nb" => self.cc_nb = Some(arg.u8_or_abort(self.field)),
+            other => {
+                abort!(
+                    self.field,
+                    "Incompatible arg `{}` for param {}",
+                    other,
+                    self.field.ty.to_token_stream(),
+                );
+            }
+        }
+    }
+
+    pub fn name(&self) -> String {
+        self.field.ty.to_token_stream().to_string().to_title_case()
     }
 }
 

--- a/jstation_derive/src/param.rs
+++ b/jstation_derive/src/param.rs
@@ -108,6 +108,35 @@ impl Arg {
             .unwrap_or_else(|| abort!(field, "attribute `{}` requires a value", self.name))
     }
 
+    pub fn u8_or_abort(&self, field: &Field) -> u8 {
+        let value = self
+            .value
+            .as_ref()
+            .unwrap_or_else(|| abort!(field, "attribute `{}` requires a value", self.name));
+
+        match value {
+            Expr::Lit(syn::ExprLit {
+                lit: syn::Lit::Int(lit_int),
+                ..
+            }) => lit_int.base10_parse::<u8>().unwrap_or_else(|err| {
+                abort!(
+                    field,
+                    "Expected a literal `u8` for `{}`: {:?}",
+                    self.name,
+                    err
+                );
+            }),
+            other => {
+                abort!(
+                    field,
+                    "Expected a literal `u8` for `{}` found {}",
+                    self.name,
+                    other.to_token_stream(),
+                )
+            }
+        }
+    }
+
     pub fn no_value_or_abort(&self, field: &Field) {
         if self.value.is_some() {
             abort!(field, "attribute `{}` doesn't accept any value", self.name);

--- a/jstation_derive/src/param_group.rs
+++ b/jstation_derive/src/param_group.rs
@@ -45,7 +45,7 @@ impl<'a> ToTokens for ParamGroup<'a> {
         // param structs declarations and traits
         tokens.extend(self.params.iter().map(|p| p.to_token_stream()));
 
-        // ParameterGroup specifics
+        // ParameterSetter specifics
         let group_name = &self.name;
 
         tokens.extend({

--- a/jstation_derive/src/param_group.rs
+++ b/jstation_derive/src/param_group.rs
@@ -36,7 +36,9 @@ impl<'a> ParamGroup<'a> {
     }
 
     fn variable_range_fields(&self) -> impl Iterator<Item = &Param<'a>> {
-        self.params.iter().filter(|param| param.is_variable_range())
+        self.params
+            .iter()
+            .filter(|param| matches!(param, Param::VariableRange(_)))
     }
 }
 
@@ -49,8 +51,8 @@ impl<'a> ToTokens for ParamGroup<'a> {
         let group_name = &self.name;
 
         tokens.extend({
-            let param_enum = self.params.iter().map(Param::typ);
-            let param_from = self.params.iter().map(Param::typ);
+            let param_enum = self.params.iter().map(Param::ty);
+            let param_from = self.params.iter().map(Param::ty);
 
             quote! {
                 #[derive(Clone, Copy, Debug)]
@@ -90,7 +92,7 @@ impl<'a> ToTokens for ParamGroup<'a> {
 
         tokens.extend({
             let variant_set_field = self.params.iter().map(|p| {
-                let variant = p.typ();
+                let variant = p.ty();
                 let field = p.field();
 
                 if p.is_discriminant() {
@@ -147,7 +149,7 @@ impl<'a> ToTokens for ParamGroup<'a> {
             // Only implement for params with a declared cc_nb
             let variant_to_cc = self.params.iter().filter_map(|p| {
                 p.cc_nb().map(|_| {
-                    let variant = p.typ();
+                    let variant = p.ty();
                     quote! {
                         Parameter::#variant(param) => param.to_cc(),
                     }
@@ -157,7 +159,7 @@ impl<'a> ToTokens for ParamGroup<'a> {
             // Note: discriminant unitity checked with ParameterSetter
             let variant_set_cc = self.params.iter().filter_map(|p| {
                 p.cc_nb().map(|cc_nb| {
-                    let variant = p.typ();
+                    let variant = p.ty();
                     let field = p.field();
 
                     if p.is_discriminant() {

--- a/jstation_derive/src/variable_range.rs
+++ b/jstation_derive/src/variable_range.rs
@@ -9,7 +9,7 @@ use crate::param::Arg;
 pub struct VariableRange<'a> {
     field: &'a Field,
     name: Option<String>,
-    param_nb: Option<Expr>,
+    param_nb: Option<u8>,
     cc_nb: Option<u8>,
 }
 
@@ -32,25 +32,8 @@ impl<'a> VariableRange<'a> {
         for arg in args {
             let name = arg.name.to_string();
             match name.as_str() {
-                "param_nb" => param.param_nb = Some(arg.value_or_abort(field)),
-                "cc_nb" => {
-                    let cc_nb = match arg.value_or_abort(field) {
-                        Expr::Lit(syn::ExprLit {
-                            lit: syn::Lit::Int(lit_int),
-                            ..
-                        }) => lit_int.base10_parse::<u8>().unwrap_or_else(|err| {
-                            abort!(field, "Expected an `u8` for `cc_nb`: {:?}", err);
-                        }),
-                        other => {
-                            abort!(
-                                field,
-                                "Expected a literal int for `cc_nb` found {}",
-                                other.to_token_stream(),
-                            )
-                        }
-                    };
-                    param.cc_nb = Some(cc_nb)
-                }
+                "param_nb" => param.param_nb = Some(arg.u8_or_abort(field)),
+                "cc_nb" => param.cc_nb = Some(arg.u8_or_abort(field)),
                 "name" => {
                     let name = match arg.value_or_abort(field) {
                         Expr::Lit(syn::ExprLit {

--- a/jstation_derive/src/variable_range.rs
+++ b/jstation_derive/src/variable_range.rs
@@ -1,83 +1,26 @@
 use proc_macro2::TokenStream;
-use proc_macro_error::{abort, ResultExt};
 use quote::{quote, ToTokens};
-use syn::{self, punctuated::Punctuated, Attribute, Expr, Field, Ident, Token, Type};
 
-use crate::param::Arg;
+use crate::param::{Arg, ParamBase};
 
-// FIXME factorize the common fields amongst all parameters
 pub struct VariableRange<'a> {
-    field: &'a Field,
-    name: Option<String>,
-    param_nb: Option<u8>,
-    cc_nb: Option<u8>,
+    pub base: ParamBase<'a>,
 }
 
 impl<'a> VariableRange<'a> {
-    fn new(field: &'a Field) -> Self {
-        VariableRange {
-            field,
-            name: None,
-            param_nb: None,
-            cc_nb: None,
-        }
-    }
-
-    pub fn from_attrs(field: &'a Field, attr: &Attribute) -> Self {
-        let mut param = VariableRange::new(field);
-
-        let args = attr
-            .parse_args_with(Punctuated::<Arg, Token![,]>::parse_terminated)
-            .unwrap_or_abort();
+    pub fn new(mut base: ParamBase<'a>, args: impl Iterator<Item = Arg>) -> Self {
         for arg in args {
-            let name = arg.name.to_string();
-            match name.as_str() {
-                "param_nb" => param.param_nb = Some(arg.u8_or_abort(field)),
-                "cc_nb" => param.cc_nb = Some(arg.u8_or_abort(field)),
-                "name" => {
-                    let name = match arg.value_or_abort(field) {
-                        Expr::Lit(syn::ExprLit {
-                            lit: syn::Lit::Str(lit_str),
-                            ..
-                        }) => lit_str.value(),
-                        other => other.to_token_stream().to_string(),
-                    };
-                    param.name = Some(name);
-                }
-                other => {
-                    abort!(
-                        field,
-                        "Incompatible arg `{}` for `variable_range` param {}",
-                        other,
-                        field.ty.to_token_stream(),
-                    );
-                }
-            }
+            base.have_arg(arg);
         }
 
-        param
-    }
-
-    pub fn typ(&self) -> &Type {
-        &self.field.ty
-    }
-
-    pub fn field(&self) -> &Ident {
-        self.field.ident.as_ref().expect("name field")
-    }
-
-    pub fn cc_nb(&self) -> Option<u8> {
-        self.cc_nb
+        VariableRange { base }
     }
 }
 
 impl<'a> ToTokens for VariableRange<'a> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        let param = self.typ();
-        let param_name = self.name.clone().unwrap_or_else(|| {
-            use heck::ToTitleCase;
-            param.to_token_stream().to_string().to_title_case()
-        });
+        let param = &self.base.field.ty;
+        let param_name = self.base.name();
 
         tokens.extend(quote! {
             #[derive(Clone, Copy, Debug, Default, PartialEq)]
@@ -161,7 +104,7 @@ impl<'a> ToTokens for VariableRange<'a> {
             }
         });
 
-        if let Some(param_nb) = &self.param_nb {
+        if let Some(param_nb) = &self.base.param_nb {
             tokens.extend(quote! {
                 impl crate::jstation::data::DiscreteRawParameter for #param {
                     const PARAMETER_NB: crate::jstation::data::ParameterNumber =
@@ -170,7 +113,7 @@ impl<'a> ToTokens for VariableRange<'a> {
             });
         }
 
-        if let Some(cc_nb) = &self.cc_nb {
+        if let Some(cc_nb) = &self.base.cc_nb {
             tokens.extend(quote! {
                 impl crate::jstation::data::CCParameter for #param {
                     fn to_cc(self) -> Option<crate::midi::CC> {

--- a/src/jstation/data/dsp/amp.rs
+++ b/src/jstation/data/dsp/amp.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 
-use jstation_derive::ParameterGroup;
+use jstation_derive::ParameterSetter;
 
-#[derive(Clone, Copy, Debug, Default, ParameterGroup)]
+#[derive(Clone, Copy, Debug, Default, ParameterSetter)]
 pub struct Amp {
     #[const_range(max = 24, param_nb = 9, cc_nb = 34, display_map = name, display_map = nick)]
     pub modeling: Modeling,

--- a/src/jstation/data/dsp/cabinet.rs
+++ b/src/jstation/data/dsp/cabinet.rs
@@ -1,6 +1,6 @@
-use jstation_derive::ParameterGroup;
+use jstation_derive::ParameterSetter;
 
-#[derive(Clone, Copy, Debug, Default, ParameterGroup)]
+#[derive(Clone, Copy, Debug, Default, ParameterSetter)]
 pub struct Cabinet {
     #[const_range(max = 18, param_nb = 15, cc_nb = 66, display_map = name, display_map = nick)]
     pub typ: Type,

--- a/src/jstation/data/dsp/compressor.rs
+++ b/src/jstation/data/dsp/compressor.rs
@@ -1,9 +1,9 @@
 use std::fmt;
 
 use crate::jstation::data::DiscreteParameter;
-use jstation_derive::ParameterGroup;
+use jstation_derive::ParameterSetter;
 
-#[derive(Clone, Copy, Debug, Default, ParameterGroup)]
+#[derive(Clone, Copy, Debug, Default, ParameterSetter)]
 pub struct Compressor {
     #[boolean(param_nb = 0, cc_nb = 1)]
     pub switch: Switch,

--- a/src/jstation/data/dsp/compressor.rs
+++ b/src/jstation/data/dsp/compressor.rs
@@ -13,7 +13,7 @@ pub struct Compressor {
     pub ratio: Ratio,
     #[const_range(max = 30, param_nb = 3, cc_nb = 4)]
     pub gain: Gain,
-    #[const_range(max = 19, param_nb = 4, cc_nb = 5, name = "Max. Freq.", display_map = value)]
+    #[const_range(max = 19, param_nb = 4, cc_nb = 5, display_map = value)]
     pub freq: Freq,
 }
 

--- a/src/jstation/data/dsp/delay.rs
+++ b/src/jstation/data/dsp/delay.rs
@@ -1,9 +1,9 @@
 use std::fmt;
 
 use crate::jstation::data::DiscreteParameter;
-use jstation_derive::ParameterGroup;
+use jstation_derive::ParameterSetter;
 
-#[derive(Clone, Copy, Debug, Default, ParameterGroup)]
+#[derive(Clone, Copy, Debug, Default, ParameterSetter)]
 pub struct Delay {
     #[boolean(param_nb = 26, cc_nb = 52)]
     pub switch: Switch,

--- a/src/jstation/data/dsp/effect.rs
+++ b/src/jstation/data/dsp/effect.rs
@@ -1,13 +1,13 @@
 use std::fmt;
 
-use jstation_derive::ParameterGroup;
+use jstation_derive::ParameterSetter;
 
 use crate::jstation::data::{
     DiscreteParameter, DiscreteRange, Normal, ParameterSetter, RawValue, VariableRange,
     VariableRangeParameter,
 };
 
-#[derive(Clone, Copy, Debug, Default, ParameterGroup)]
+#[derive(Clone, Copy, Debug, Default, ParameterSetter)]
 pub struct Effect {
     #[boolean(param_nb = 19, cc_nb = 44)]
     pub switch: Switch,

--- a/src/jstation/data/dsp/noise_gate.rs
+++ b/src/jstation/data/dsp/noise_gate.rs
@@ -1,6 +1,6 @@
-use jstation_derive::ParameterGroup;
+use jstation_derive::ParameterSetter;
 
-#[derive(Clone, Copy, Debug, Default, ParameterGroup)]
+#[derive(Clone, Copy, Debug, Default, ParameterSetter)]
 pub struct NoiseGate {
     #[boolean(param_nb = 16, cc_nb = 41)]
     pub switch: Switch,

--- a/src/jstation/data/dsp/reverb.rs
+++ b/src/jstation/data/dsp/reverb.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 
-use jstation_derive::ParameterGroup;
+use jstation_derive::ParameterSetter;
 
-#[derive(Clone, Copy, Debug, Default, ParameterGroup)]
+#[derive(Clone, Copy, Debug, Default, ParameterSetter)]
 pub struct Reverb {
     #[boolean(param_nb = 32, cc_nb = 59)]
     pub switch: Switch,

--- a/src/jstation/data/dsp/utility_settings.rs
+++ b/src/jstation/data/dsp/utility_settings.rs
@@ -1,8 +1,8 @@
 use crate::jstation::procedure::UtilitySettingsResp;
-use jstation_derive::ParameterGroup;
+use jstation_derive::ParameterSetter;
 
 // FIXME might be easier not to auto implement ParameterSetter
-#[derive(Clone, Copy, Debug, Default, ParameterGroup)]
+#[derive(Clone, Copy, Debug, Default, ParameterSetter)]
 pub struct UtilitySettings {
     pub stereo_mono: bool,
     pub dry_track: bool,

--- a/src/jstation/data/dsp/wah_expr.rs
+++ b/src/jstation/data/dsp/wah_expr.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 
-use jstation_derive::ParameterGroup;
+use jstation_derive::ParameterSetter;
 
-#[derive(Clone, Copy, Debug, Default, ParameterGroup)]
+#[derive(Clone, Copy, Debug, Default, ParameterSetter)]
 pub struct WahExpr {
     #[boolean(param_nb = 5, cc_nb = 8)]
     pub switch: Switch,


### PR DESCRIPTION
- Remove unused proc macro attribute arguments.
- Factorize common arguments handling.