### PR TITLE
U8 normal

### DIFF
--- a/jstation_derive/src/const_range.rs
+++ b/jstation_derive/src/const_range.rs
@@ -157,7 +157,7 @@ impl<'a> ToTokens for ConstRange<'a> {
 
                 fn to_raw_value(self) -> Option<crate::jstation::data::RawValue> {
                     use crate::jstation::data::ConstRangeParameter;
-                    Some(self.0.get_raw(Self::RANGE))
+                    Some(self.0.to_raw(Self::RANGE))
                 }
 
                 fn reset(&mut self) -> Option<Self> {

--- a/jstation_derive/src/const_range.rs
+++ b/jstation_derive/src/const_range.rs
@@ -42,6 +42,10 @@ impl<'a> ConstRange<'a> {
                 arg.no_value_or_abort(self.base.field);
                 self.default_center = true;
             }
+            "display_cent" => {
+                arg.no_value_or_abort(self.base.field);
+                self.displays.push(Display::Cent);
+            }
             "display_raw" => {
                 arg.no_value_or_abort(self.base.field);
                 self.displays.push(Display::Raw);
@@ -236,6 +240,14 @@ impl<'a> ToTokens for ConstRange<'a> {
 
         for display in self.displays.iter() {
             match display {
+                Display::Cent => tokens.extend(quote! {
+                    impl std::fmt::Display for #param {
+                        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                            use crate::jstation::data::DiscreteParameter;
+                            fmt::Display::fmt(&self.normal().unwrap().as_cents(), f)
+                        }
+                    }
+                }),
                 Display::Raw => tokens.extend(quote! {
                     impl std::fmt::Display for #param {
                         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -336,6 +348,7 @@ impl<'a> ToTokens for ConstRange<'a> {
 }
 
 enum Display {
+    Cent,
     Raw,
     Map(Ident),
 }

--- a/src/jstation/data/dsp/amp.rs
+++ b/src/jstation/data/dsp/amp.rs
@@ -1,14 +1,15 @@
 use std::fmt;
 
+use crate::jstation::data::DiscreteParameter;
 use jstation_derive::ParameterSetter;
 
 #[derive(Clone, Copy, Debug, Default, ParameterSetter)]
 pub struct Amp {
     #[const_range(max = 24, param_nb = 9, cc_nb = 34, display_map = name, display_map = nick)]
     pub modeling: Modeling,
-    #[const_range(max = 90, param_nb = 10, cc_nb = 35)]
+    #[const_range(max = 90, param_nb = 10, cc_nb = 35, display_cent)]
     pub gain: Gain,
-    #[const_range(max = 90, param_nb = 14, cc_nb = 36)]
+    #[const_range(max = 90, param_nb = 14, cc_nb = 36, display_cent)]
     pub level: Level,
     #[const_range(max = 90, default_center, param_nb = 13, cc_nb = 37)]
     pub bass: Bass,
@@ -74,32 +75,29 @@ const MODELING_NICKS: [&str; 25] = [
     "Direct (A8)",
 ];
 
-impl fmt::Display for Gain {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        super::fmt_percent(*self, f)
-    }
-}
-
-impl fmt::Display for Level {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        super::fmt_percent(*self, f)
+fn fmt_bipolar_normal(param: impl DiscreteParameter, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    if let Some(normal) = param.normal() {
+        let bipolar = 20.0 * normal.as_ratio() - 10.0;
+        f.write_fmt(format_args!("{:0.1}", bipolar))
+    } else {
+        f.write_str("n/a")
     }
 }
 
 impl fmt::Display for Bass {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        super::fmt_bipolar_normal(*self, f)
+        fmt_bipolar_normal(*self, f)
     }
 }
 
 impl fmt::Display for Middle {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        super::fmt_bipolar_normal(*self, f)
+        fmt_bipolar_normal(*self, f)
     }
 }
 
 impl fmt::Display for Treble {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        super::fmt_bipolar_normal(*self, f)
+        fmt_bipolar_normal(*self, f)
     }
 }

--- a/src/jstation/data/dsp/delay.rs
+++ b/src/jstation/data/dsp/delay.rs
@@ -26,7 +26,7 @@ const TYPE_NAMES: [&str; 4] = ["Mono", "Analog", "Pong", "Analog Pong"];
 
 impl fmt::Display for Level {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        super::fmt_percent(*self, f)
+        fmt::Display::fmt(&self.normal().unwrap().as_cents(), f)
     }
 }
 
@@ -51,6 +51,6 @@ impl fmt::Display for TimeFine {
 
 impl fmt::Display for Feedback {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        super::fmt_percent(*self, f)
+        fmt::Display::fmt(&self.normal().unwrap().as_cents(), f)
     }
 }

--- a/src/jstation/data/dsp/effect.rs
+++ b/src/jstation/data/dsp/effect.rs
@@ -135,7 +135,7 @@ impl DiscreteParameter for Speed {
     }
 
     fn to_raw_value(self) -> Option<RawValue> {
-        Some(self.value.get_raw(self.range().unwrap()))
+        Some(self.value.to_raw(self.range().unwrap()))
     }
 
     fn reset(&mut self) -> Option<Self> {
@@ -162,7 +162,7 @@ impl fmt::Display for Speed {
                 // -24 to +24 semitones.
                 self.to_raw_value().unwrap().as_u8() as i32 - 24i32
             }
-            _ => (100.0 * self.value.normal().as_f32()) as i32,
+            _ => self.value.normal().as_cents() as i32,
         };
 
         fmt::Display::fmt(&value, f)
@@ -231,7 +231,7 @@ impl DiscreteParameter for Depth {
     }
 
     fn to_raw_value(self) -> Option<RawValue> {
-        Some(self.value.get_raw(self.range().unwrap()))
+        Some(self.value.to_raw(self.range().unwrap()))
     }
 
     fn reset(&mut self) -> Option<Self> {
@@ -246,7 +246,7 @@ impl fmt::Display for Depth {
                 // -30 to +30 cents.
                 self.to_raw_value().unwrap().as_u8() as i32 - 30i32
             }
-            _ => (100.0 * self.value.normal().as_f32()) as i32,
+            _ => self.value.normal().as_cents() as i32,
         };
 
         fmt::Display::fmt(&value, f)
@@ -292,7 +292,7 @@ impl DiscreteParameter for Regen {
     }
 
     fn to_raw_value(self) -> Option<RawValue> {
-        self.range().map(|range| self.value.get_raw(range))
+        self.range().map(|range| self.value.to_raw(range))
     }
 
     fn reset(&mut self) -> Option<Self> {
@@ -312,7 +312,7 @@ impl DiscreteParameter for Regen {
 impl fmt::Display for Regen {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.is_active() {
-            fmt::Display::fmt(&((100.0 * self.value.normal().as_f32()) as i32), f)
+            fmt::Display::fmt(&self.value.normal().as_cents(), f)
         } else {
             f.write_str("n/a")
         }

--- a/src/jstation/data/dsp/effect.rs
+++ b/src/jstation/data/dsp/effect.rs
@@ -13,7 +13,7 @@ pub struct Effect {
     pub switch: Switch,
     #[const_range(discriminant, max = 6, param_nb = 20, cc_nb = 45, display_map = name)]
     pub typ: Type,
-    #[const_range(max = 99, param_nb = 21, cc_nb = 46)]
+    #[const_range(max = 99, param_nb = 21, cc_nb = 46, display_cent)]
     pub mix: Mix,
     // The speed parameter changes assignment depending on the effect type:
     // - For Auto Wah, it's the WahType with 3 possible values.
@@ -73,12 +73,6 @@ const TYPE_NAMES: [&str; 7] = [
     "Auto Wah",
     "Pitch / Detune",
 ];
-
-impl fmt::Display for Mix {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        super::fmt_percent(*self, f)
-    }
-}
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub enum SpeedAssignment {

--- a/src/jstation/data/dsp/mod.rs
+++ b/src/jstation/data/dsp/mod.rs
@@ -127,7 +127,7 @@ impl CCParameterSetter for Dsp {
 
 fn fmt_percent(param: impl DiscreteParameter, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     if let Some(normal) = param.normal() {
-        f.write_fmt(format_args!("{:.0}", 100.0 * normal.as_f32()))
+        f.write_fmt(format_args!("{:.0}", 100.0 * normal.as_ratio()))
     } else {
         f.write_str("n/a")
     }
@@ -135,7 +135,7 @@ fn fmt_percent(param: impl DiscreteParameter, f: &mut fmt::Formatter<'_>) -> fmt
 
 fn fmt_bipolar_normal(param: impl DiscreteParameter, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     if let Some(normal) = param.normal() {
-        let bipolar = 2.0 * normal.as_f32() - 1.0;
+        let bipolar = 2.0 * normal.as_ratio() - 1.0;
         f.write_fmt(format_args!("{:0.2}", bipolar))
     } else {
         f.write_str("n/a")

--- a/src/jstation/data/dsp/mod.rs
+++ b/src/jstation/data/dsp/mod.rs
@@ -1,8 +1,6 @@
-use std::fmt;
-
 use crate::{
     jstation::{
-        data::{CCParameter, CCParameterSetter, DiscreteParameter, ParameterSetter},
+        data::{CCParameter, CCParameterSetter, ParameterSetter},
         Error,
     },
     midi,
@@ -122,22 +120,5 @@ impl CCParameterSetter for Dsp {
         try_set_cc!(self.utility_settings, cc, UtilitySettings);
 
         Err(Error::CCNumberUnknown(cc.nb.as_u8()))
-    }
-}
-
-fn fmt_percent(param: impl DiscreteParameter, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    if let Some(normal) = param.normal() {
-        f.write_fmt(format_args!("{:.0}", 100.0 * normal.as_ratio()))
-    } else {
-        f.write_str("n/a")
-    }
-}
-
-fn fmt_bipolar_normal(param: impl DiscreteParameter, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    if let Some(normal) = param.normal() {
-        let bipolar = 2.0 * normal.as_ratio() - 1.0;
-        f.write_fmt(format_args!("{:0.2}", bipolar))
-    } else {
-        f.write_str("n/a")
     }
 }

--- a/src/jstation/data/dsp/reverb.rs
+++ b/src/jstation/data/dsp/reverb.rs
@@ -8,11 +8,11 @@ pub struct Reverb {
     pub switch: Switch,
     #[const_range(max = 12, param_nb = 33, cc_nb = 60, display_map = name)]
     pub typ: Type,
-    #[const_range(max = 99, param_nb = 34, cc_nb = 61)]
+    #[const_range(max = 99, param_nb = 34, cc_nb = 61, display_cent)]
     pub level: Level,
-    #[const_range(max = 99, param_nb = 35, cc_nb = 62)]
+    #[const_range(max = 99, param_nb = 35, cc_nb = 62, display_cent)]
     pub diffusion: Diffusion,
-    #[const_range(max = 99, param_nb = 36, cc_nb = 63)]
+    #[const_range(max = 99, param_nb = 36, cc_nb = 63, display_cent)]
     pub density: Density,
     #[const_range(max = 9, param_nb = 37, cc_nb = 65, display_raw)]
     pub decay: Decay,
@@ -33,21 +33,3 @@ const TYPE_NAMES: [&str; 13] = [
     "3x 14\" springs",
     "Rattle & Boing",
 ];
-
-impl fmt::Display for Level {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        super::fmt_percent(*self, f)
-    }
-}
-
-impl fmt::Display for Diffusion {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        super::fmt_percent(*self, f)
-    }
-}
-
-impl fmt::Display for Density {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        super::fmt_percent(*self, f)
-    }
-}

--- a/src/jstation/data/dsp/wah_expr.rs
+++ b/src/jstation/data/dsp/wah_expr.rs
@@ -9,28 +9,16 @@ pub struct WahExpr {
     // Doc says "reserved for future use".
     //#[const_range(max = ?, param_nb = 6, cc_nb = 9)]
     //pub typ: Type,
-    #[const_range(max = 127, param_nb = 7, cc_nb = 10)]
+    #[const_range(max = 127, param_nb = 7, cc_nb = 10, display_cent)]
     pub heel: Heel,
-    #[const_range(max = 127, param_nb = 8, cc_nb = 11)]
+    #[const_range(max = 127, param_nb = 8, cc_nb = 11, display_cent)]
     pub toe: Toe,
     #[const_range(max = 14, param_nb = 40, cc_nb = 70, display_map = name)]
     pub assignment: Assignment,
-    #[const_range(max = 127, param_nb = 41, cc_nb = 71)]
+    #[const_range(max = 127, param_nb = 41, cc_nb = 71, display_cent)]
     pub forward: Forward,
-    #[const_range(max = 127, param_nb = 42, cc_nb = 72)]
+    #[const_range(max = 127, param_nb = 42, cc_nb = 72, display_cent)]
     pub back: Back,
-}
-
-impl fmt::Display for Heel {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        super::fmt_percent(*self, f)
-    }
-}
-
-impl fmt::Display for Toe {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        super::fmt_percent(*self, f)
-    }
 }
 
 const ASSIGNMENT_NAMES: [&str; 15] = [
@@ -50,15 +38,3 @@ const ASSIGNMENT_NAMES: [&str; 15] = [
     "Delay Feedback",
     "Reverb Level",
 ];
-
-impl fmt::Display for Forward {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        super::fmt_percent(*self, f)
-    }
-}
-
-impl fmt::Display for Back {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        super::fmt_percent(*self, f)
-    }
-}

--- a/src/jstation/data/parameter/normal.rs
+++ b/src/jstation/data/parameter/normal.rs
@@ -1,49 +1,101 @@
 use crate::{jstation::Error, midi::CCValue};
 
-#[derive(Copy, Clone, Debug, Default, PartialEq, PartialOrd)]
-pub struct Normal(f32);
+/// A Normal value baed on an `u8`.
+///
+/// Internal computation uses an `u32` so as to reduce precision loss.
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, PartialOrd)]
+pub struct Normal(u8);
 
 impl Normal {
-    pub const MIN: Normal = Normal(0.0);
-    pub const CENTER: Normal = Normal(0.5);
-    pub const MAX: Normal = Normal(1.0);
+    pub const MIN: Normal = Normal(0);
+    pub const CENTER: Normal = Normal(0x80);
+    pub const MAX: Normal = Normal(0xff);
 
-    const MAX_CC_VALUE: f32 = CCValue::MAX.as_u8() as f32;
+    const MAX_U32: u32 = Self::MAX.0 as u32;
+    const SCALE: u32 = 0x1000;
+    const ROUNDING: u32 = Self::SCALE / 2;
+    const MAX_SCALED: u32 = Self::MAX_U32 * Self::SCALE;
 
-    pub const fn as_f32(self) -> f32 {
+    const MAX_F32: f32 = Self::MAX.0 as f32;
+    const MAX_RECIP_F32: f32 = 1.0 / (Self::MAX.0 as f32);
+
+    pub const fn as_u8(self) -> u8 {
         self.0
     }
 
-    pub fn into_cc_value(self) -> CCValue {
-        // FIXME we could impl `CCValue::new_unchecked` instead.
-        CCValue::new_clipped((self.0 * Self::MAX_CC_VALUE) as u8)
+    pub fn as_ratio(self) -> f32 {
+        self.0 as f32 * Normal::MAX_RECIP_F32
     }
 
-    /// Builds a `Normal` from the provided value, whithout checking it.
+    pub fn as_cents(self) -> u16 {
+        ((self.0 as u32 * 100 * Self::SCALE + Self::ROUNDING) / Self::MAX_SCALED) as u16
+    }
+
+    // FIXME for all the function below, range must NOT exceed RawValue::MAX...
+
+    /// Tries to build a `Normal` from the provided zero based value and range.
     ///
-    /// # Safety
-    ///
-    /// The value must be in the range `(0.0..=1.0)`.
-    pub unsafe fn new_unchecked(normal: f32) -> Self {
-        Normal(normal)
+    /// Returns an `Error` if the `value` is greated than `max`.
+    pub fn try_normalize(value: u8, range: u8) -> Result<Normal, Error> {
+        if value > range {
+            return Err(Error::ValueOutOfRange {
+                value,
+                min: 0,
+                max: range,
+            });
+        }
+
+        let value = value as u32;
+        let range = range as u32;
+
+        Ok(Self::normalize_priv(value, range))
+    }
+
+    fn normalize_priv(value: u32, range: u32) -> Normal {
+        Normal(((value * Self::MAX_SCALED / range + Self::ROUNDING) / Self::SCALE) as u8)
+    }
+
+    /// Maps this `Normal` to the provided range.
+    pub fn map_to(self, range: u8) -> u8 {
+        let range = range as u32;
+
+        self.map_to_priv(range) as u8
+    }
+
+    #[inline(always)]
+    fn map_to_priv(self, range: u32) -> u32 {
+        // round up otherwise the decimal value is simply truncated.
+        (self.0 as u32 * range * Self::SCALE / Self::MAX_U32 + Self::ROUNDING) / Self::SCALE
+    }
+
+    /// Snaps this `Normal` to the quantification of the provided range.
+    pub fn snap_to(self, range: u8) -> Normal {
+        let range = range as u32;
+        let value = self.map_to_priv(range);
+
+        Self::normalize_priv(value, range)
     }
 }
 
 impl From<Normal> for CCValue {
     fn from(normal: Normal) -> Self {
-        normal.into_cc_value()
+        unsafe {
+            // Safety: CC Value is 0 based and we know how to map this normal
+            // to the CCValue's range.
+            std::mem::transmute(normal.map_to(CCValue::MAX.as_u8()))
+        }
     }
 }
 
 impl From<CCValue> for Normal {
     fn from(value: CCValue) -> Self {
-        Normal(value.as_u8() as f32 / Normal::MAX_CC_VALUE)
+        Self::normalize_priv(value.as_u8() as u32, CCValue::MAX.as_u8() as u32)
     }
 }
 
 impl From<Normal> for f32 {
-    fn from(normal: Normal) -> Self {
-        normal.0
+    fn from(normal: Normal) -> f32 {
+        normal.as_ratio()
     }
 }
 
@@ -55,7 +107,7 @@ impl TryFrom<f32> for Normal {
             return Err(Error::NormalOutOfRange(value));
         }
 
-        Ok(Normal(value))
+        Ok(Normal((value * Self::MAX_F32).ceil() as u8))
     }
 }
 
@@ -69,14 +121,60 @@ mod tests {
         assert_eq!(Normal::try_from(0.5).unwrap(), Normal::CENTER);
         assert_eq!(Normal::try_from(1.0).unwrap(), Normal::MAX);
 
-        match Normal::try_from(Normal::MIN.0 - f32::EPSILON).unwrap_err() {
-            Error::NormalOutOfRange(val) => assert_eq!(val, Normal::MIN.0 - f32::EPSILON),
+        match Normal::try_from(0.0 - f32::EPSILON).unwrap_err() {
+            Error::NormalOutOfRange(val) => assert_eq!(val, 0.0 - f32::EPSILON),
             other => panic!("{other}"),
         }
 
-        match Normal::try_from(Normal::MAX.0 + f32::EPSILON).unwrap_err() {
-            Error::NormalOutOfRange(val) => assert_eq!(val, Normal::MAX.0 + f32::EPSILON),
+        match Normal::try_from(Normal::MAX_F32 + f32::EPSILON).unwrap_err() {
+            Error::NormalOutOfRange(val) => assert_eq!(val, Normal::MAX_F32 + f32::EPSILON),
             other => panic!("{other}"),
+        }
+    }
+
+    #[test]
+    fn round_trip() {
+        const FORTY_NINE: u8 = 49;
+        const RANGE: u8 = 97;
+
+        let normal = Normal::try_normalize(0, RANGE).unwrap();
+        assert_eq!(normal, Normal::MIN);
+        assert_eq!(normal.map_to(RANGE), 0);
+
+        let normal = Normal::try_normalize(FORTY_NINE, RANGE).unwrap();
+        assert_eq!(normal.map_to(RANGE), FORTY_NINE);
+
+        let normal = Normal::try_normalize(RANGE, RANGE).unwrap();
+        assert_eq!(normal, Normal::MAX);
+        assert_eq!(normal.map_to(RANGE), RANGE);
+    }
+
+    #[test]
+    fn snap_to() {
+        const R23: u8 = 23;
+        const R24: u8 = 24;
+        const R25: u8 = 25;
+
+        assert_eq!(Normal::CENTER.snap_to(R23).map_to(R23), 12);
+        assert_eq!(Normal::CENTER.snap_to(R24).map_to(R24), 12);
+        assert_eq!(Normal::CENTER.snap_to(R25).map_to(R25), 13);
+
+        let normal_third = Normal::try_from(1.0 / 3.0).unwrap();
+        assert_eq!(normal_third.snap_to(R23).map_to(R23), 8);
+        assert_eq!(normal_third.snap_to(R24).map_to(R24), 8);
+        assert_eq!(normal_third.snap_to(R25).map_to(R25), 8);
+
+        assert_eq!(Normal::MAX.snap_to(R24).map_to(R24), 24);
+        assert_eq!(Normal::MAX.snap_to(R25).map_to(R25), 25);
+    }
+
+    #[test]
+    fn out_of_range() {
+        let res = Normal::try_normalize(11, 10);
+        if let Error::ValueOutOfRange { value, min, max } = res.unwrap_err() {
+            assert_eq!(value, 11);
+            assert_eq!(min, 0);
+            assert_eq!(max, 10);
         }
     }
 

--- a/src/jstation/data/parameter/raw.rs
+++ b/src/jstation/data/parameter/raw.rs
@@ -27,9 +27,10 @@ pub struct RawValue(u8);
 
 impl RawValue {
     pub const ZERO: Self = RawValue(0);
-    pub const CENTER: Self = RawValue(0x7f);
+    pub const MIN: Self = RawValue(0);
     pub const MAX: Self = RawValue(0xff);
 
+    /// Builds a `RawValue`.
     pub const fn new(value: u8) -> Self {
         RawValue(value)
     }
@@ -41,7 +42,7 @@ impl RawValue {
 
 impl From<u8> for RawValue {
     fn from(value: u8) -> Self {
-        Self(value)
+        RawValue(value)
     }
 }
 

--- a/src/jstation/error.rs
+++ b/src/jstation/error.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::{jstation::data::RawValue, midi};
+use crate::midi;
 
 #[derive(Clone, Debug, thiserror::Error)]
 pub enum Error {
@@ -13,12 +13,8 @@ pub enum Error {
     #[error("Parameter number {} out of range", .0)]
     ParameterNumberOutOfRange(u8),
 
-    #[error("Parameter raw value {} out of range: ({}..={})", .value, .min, .max)]
-    ParameterRawValueOutOfRange {
-        value: RawValue,
-        min: RawValue,
-        max: RawValue,
-    },
+    #[error("Value {} out of range: ({}..={})", .value, .min, .max)]
+    ValueOutOfRange { value: u8, min: u8, max: u8 },
 
     #[error("Program number {} out of range", .0)]
     ProgramNumberOutOfRange(u8),

--- a/src/jstation/procedure/utility_settings.rs
+++ b/src/jstation/procedure/utility_settings.rs
@@ -61,7 +61,7 @@ impl UtilitySettingsResp {
         Ok((i, UtilitySettingsResp {
             stereo_mono,
             dry_track,
-            digital_out_level: digital_out_level.into(),
+            digital_out_level: RawValue::try_from(digital_out_level).unwrap(),
             global_cabinet,
             midi_merge,
             midi_channel,


### PR DESCRIPTION
`Normal` used to be implemented with an `f32` which eased computation and provided good precision.

This commit uses an `u8` instead in order to reduce the size of the discrete parameters and DSPs, thus improving cache locality and speeding up `struct` copies.

Internal computation uses an `u32` to reduce precision loss.