### PR TITLE
Rebase to latest iced

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1266,7 +1266,7 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 [[package]]
 name = "iced"
 version = "0.6.0"
-source = "git+https://github.com/fengalin/iced?branch=subscription-unfold-none-handling#043b6918927cffa0e92a1ffce37a0d3cbc5a7702"
+source = "git+https://github.com/fengalin/iced?branch=subscription-unfold-none-handling#3ab18d23b7df3b8de88aec27322d225590b057cb"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -1293,7 +1293,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.6.2"
-source = "git+https://github.com/fengalin/iced?branch=subscription-unfold-none-handling#043b6918927cffa0e92a1ffce37a0d3cbc5a7702"
+source = "git+https://github.com/fengalin/iced?branch=subscription-unfold-none-handling#3ab18d23b7df3b8de88aec27322d225590b057cb"
 dependencies = [
  "bitflags",
  "palette",
@@ -1303,7 +1303,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.5.1"
-source = "git+https://github.com/fengalin/iced?branch=subscription-unfold-none-handling#043b6918927cffa0e92a1ffce37a0d3cbc5a7702"
+source = "git+https://github.com/fengalin/iced?branch=subscription-unfold-none-handling#3ab18d23b7df3b8de88aec27322d225590b057cb"
 dependencies = [
  "futures",
  "log",
@@ -1314,8 +1314,8 @@ dependencies = [
 
 [[package]]
 name = "iced_glow"
-version = "0.5.0"
-source = "git+https://github.com/fengalin/iced?branch=subscription-unfold-none-handling#043b6918927cffa0e92a1ffce37a0d3cbc5a7702"
+version = "0.5.1"
+source = "git+https://github.com/fengalin/iced?branch=subscription-unfold-none-handling#3ab18d23b7df3b8de88aec27322d225590b057cb"
 dependencies = [
  "bytemuck",
  "euclid",
@@ -1330,7 +1330,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.5.0"
-source = "git+https://github.com/fengalin/iced?branch=subscription-unfold-none-handling#043b6918927cffa0e92a1ffce37a0d3cbc5a7702"
+source = "git+https://github.com/fengalin/iced?branch=subscription-unfold-none-handling#3ab18d23b7df3b8de88aec27322d225590b057cb"
 dependencies = [
  "bitflags",
  "bytemuck",
@@ -1347,7 +1347,7 @@ dependencies = [
 [[package]]
 name = "iced_lazy"
 version = "0.3.0"
-source = "git+https://github.com/fengalin/iced?branch=subscription-unfold-none-handling#043b6918927cffa0e92a1ffce37a0d3cbc5a7702"
+source = "git+https://github.com/fengalin/iced?branch=subscription-unfold-none-handling#3ab18d23b7df3b8de88aec27322d225590b057cb"
 dependencies = [
  "iced_native",
  "ouroboros",
@@ -1356,7 +1356,7 @@ dependencies = [
 [[package]]
 name = "iced_native"
 version = "0.7.0"
-source = "git+https://github.com/fengalin/iced?branch=subscription-unfold-none-handling#043b6918927cffa0e92a1ffce37a0d3cbc5a7702"
+source = "git+https://github.com/fengalin/iced?branch=subscription-unfold-none-handling#3ab18d23b7df3b8de88aec27322d225590b057cb"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -1369,7 +1369,7 @@ dependencies = [
 [[package]]
 name = "iced_style"
 version = "0.5.1"
-source = "git+https://github.com/fengalin/iced?branch=subscription-unfold-none-handling#043b6918927cffa0e92a1ffce37a0d3cbc5a7702"
+source = "git+https://github.com/fengalin/iced?branch=subscription-unfold-none-handling#3ab18d23b7df3b8de88aec27322d225590b057cb"
 dependencies = [
  "iced_core",
  "once_cell",
@@ -1379,7 +1379,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.7.0"
-source = "git+https://github.com/fengalin/iced?branch=subscription-unfold-none-handling#043b6918927cffa0e92a1ffce37a0d3cbc5a7702"
+source = "git+https://github.com/fengalin/iced?branch=subscription-unfold-none-handling#3ab18d23b7df3b8de88aec27322d225590b057cb"
 dependencies = [
  "bitflags",
  "bytemuck",
@@ -1399,7 +1399,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.6.0"
-source = "git+https://github.com/fengalin/iced?branch=subscription-unfold-none-handling#043b6918927cffa0e92a1ffce37a0d3cbc5a7702"
+source = "git+https://github.com/fengalin/iced?branch=subscription-unfold-none-handling#3ab18d23b7df3b8de88aec27322d225590b057cb"
 dependencies = [
  "iced_futures",
  "iced_graphics",

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ pub fn main() -> iced::Result {
     use iced::Application;
     ui::App::run(iced::Settings {
         window: iced::window::Settings {
-            size: (800, 830),
+            size: (800, 850),
             ..Default::default()
         },
         ..Default::default()


### PR DESCRIPTION
Temporarily enlarge the window's height to workaround a regression with iced layout handling when the content can't shrink more.