### PR TITLE
Multiple parameter related fixes

### DIFF
--- a/jstation_derive/src/boolean.rs
+++ b/jstation_derive/src/boolean.rs
@@ -44,7 +44,7 @@ impl<'a> ToTokens for Boolean<'a> {
                 const TRUE: Self = #param(true);
                 const FALSE: Self = #param(false);
 
-                fn name(self) -> &'static str {
+                fn param_name(self) -> &'static str {
                     #param_name
                 }
             }

--- a/jstation_derive/src/param_group.rs
+++ b/jstation_derive/src/param_group.rs
@@ -159,8 +159,25 @@ impl<'a> ToTokens for ParamGroup<'a> {
         if let Some(params) = self.sorted_by_param_nb() {
             let set_field = params.map(|p| {
                 let field = p.field();
-                quote! {
-                    self.#field.set_raw(data)?;
+
+                if p.is_discriminant() {
+                    let variable_range_field =
+                        self.variable_range_fields().map(|param| param.field());
+
+                    quote! {
+                        self.#field.set_raw(data)?;
+
+                        #(
+                            crate::jstation::data::VariableRangeParameter::set_discriminant(
+                                &mut self.#variable_range_field,
+                                self.#field.into(),
+                            );
+                        )*
+                    }
+                } else {
+                    quote! {
+                        self.#field.set_raw(data)?;
+                    }
                 }
             });
 

--- a/jstation_derive/src/variable_range.rs
+++ b/jstation_derive/src/variable_range.rs
@@ -67,7 +67,11 @@ impl<'a> ToTokens for VariableRange<'a> {
                     use crate::jstation::Error;
 
                     let range = <Self as crate::jstation::data::VariableRange>::range_from(discr)
-                        .ok_or_else(|| Error::ParameterInactive(stringify!(#param).into()))?;
+                        .ok_or_else(|| Error::ParameterInactive {
+                            param: stringify!(#param).to_string(),
+                            discriminant: format!("{:?}", discr),
+                            value: raw.into(),
+                        })?;
                     let value = range
                         .check(raw)
                         .map_err(|err| crate::jstation::Error::with_context(
@@ -148,7 +152,11 @@ impl<'a> ToTokens for VariableRange<'a> {
                         assert_eq!(cc.nb.as_u8(), #cc_nb);
 
                         let range = self.range()
-                            .ok_or_else(|| Error::ParameterInactive(stringify!(#param).into()))?;
+                            .ok_or_else(|| Error::ParameterInactive {
+                                param: stringify!(#param).to_string(),
+                                discriminant: format!("{:?}", self.discr),
+                                value: cc.value.into(),
+                            })?;
                         let value = range.cc_to_raw(cc.value);
 
                         if self.value == value {

--- a/jstation_derive/src/variable_range.rs
+++ b/jstation_derive/src/variable_range.rs
@@ -70,7 +70,10 @@ impl<'a> ToTokens for VariableRange<'a> {
                         .ok_or_else(|| Error::ParameterInactive(stringify!(#param).into()))?;
                     let value = range
                         .check(raw)
-                        .map_err(|err| crate::jstation::Error::with_context(#param_name, err))?;
+                        .map_err(|err| crate::jstation::Error::with_context(
+                            format!("{} ({:?})", #param_name, discr),
+                            err,
+                        ))?;
 
                     Ok(#param {
                         discr,

--- a/src/jstation/data/dsp/delay.rs
+++ b/src/jstation/data/dsp/delay.rs
@@ -15,8 +15,7 @@ pub struct Delay {
     #[const_range(max = 30, param_nb = 29, cc_nb = 55)]
     pub time_course: TimeCourse,
     // 1 ms increments.
-    // FIXME check whether we really start at 1, why not 0?
-    #[const_range(min = 1, max = 99, param_nb = 30, cc_nb = 56)]
+    #[const_range(max = 99, param_nb = 30, cc_nb = 56)]
     pub time_fine: TimeFine,
     #[const_range(max = 99, param_nb = 31, cc_nb = 57, display_cents)]
     pub feedback: Feedback,

--- a/src/jstation/data/parameter/boolean.rs
+++ b/src/jstation/data/parameter/boolean.rs
@@ -13,7 +13,7 @@ pub trait BoolParameter:
     const TRUE: Self;
     const FALSE: Self;
 
-    fn name(self) -> &'static str;
+    fn param_name(self) -> &'static str;
 
     fn from_raw(raw: RawValue) -> Self {
         (raw.as_u8() == 0).into()

--- a/src/jstation/data/parameter/variable_range.rs
+++ b/src/jstation/data/parameter/variable_range.rs
@@ -14,7 +14,7 @@ pub trait VariableRangeParameter:
 }
 
 pub trait VariableRange: Clone + Copy {
-    type Discriminant: Clone + Copy + Default + PartialEq;
+    type Discriminant: Clone + Copy + Default + std::fmt::Debug + PartialEq;
 
     fn range_from(discr: Self::Discriminant) -> Option<DiscreteRange>;
 }

--- a/src/jstation/error.rs
+++ b/src/jstation/error.rs
@@ -7,8 +7,12 @@ pub enum Error {
     #[error("Unknown J-Station CC number {}", .0)]
     CCNumberUnknown(u8),
 
-    #[error("Inactive Parameter {}", .0)]
-    ParameterInactive(String),
+    #[error("Inactive Parameter {} (discriminant {}), value {}", .param, .discriminant, .value)]
+    ParameterInactive {
+        param: String,
+        discriminant: String,
+        value: u8,
+    },
 
     #[error("Parameter number {} out of range", .0)]
     ParameterNumberOutOfRange(u8),
@@ -68,5 +72,9 @@ impl Error {
 
     pub fn is_unknown_cc(&self) -> bool {
         matches!(self, Error::CCNumberUnknown(_))
+    }
+
+    pub fn is_inactive_param(&self) -> bool {
+        matches!(self, Error::ParameterInactive { .. })
     }
 }

--- a/src/jstation/error.rs
+++ b/src/jstation/error.rs
@@ -52,12 +52,12 @@ pub enum Error {
 
 impl Error {
     // FIXME there must be a better way...
-    pub fn with_context<E>(ctx: &'static str, source: E) -> Self
+    pub fn with_context<E>(ctx: impl Into<Arc<str>>, source: E) -> Self
     where
         E: 'static + std::error::Error + Send + Sync,
     {
         Error::WithContext {
-            ctx: Arc::from(ctx),
+            ctx: ctx.into(),
             source: Arc::new(source),
         }
     }


### PR DESCRIPTION
This PR fixes the followings:

- Doc says delay's time fine parameter starts at 1, which didn't seem right in the first place, and is contradicted by some programs which use 0 for this parameter.
- Fix discriminant not set by `ParamGroup` `set_raw`: this was properly done by `set_cc`, but was not implemented when Program raw data reflection on the UI.
- A value is available as part of the Program Data no matter what, so don't error out attempting to set an inactive parameter.