### PR TITLE
Add Programs Bank support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,13 @@ While it is usable to control a J-Station, this application is a work in progres
 
 - [X] Scan the available MIDI ports for a J-Station device.
 - [X] Download device Programs.
-- [X] Show the parameters for selected Program. FIXME: Bank selection not handled ATM.
+- [X] Show the parameters for selected Program.
 - [X] Use the UI to update a parameter.
 - [X] Reflect device parameters updates on the UI.
-- [X] Show the list of Programs. FIXME: Bank selection not handled ATM.
-- [X] Change Program from the UI. FIXME: Bank selection not handled ATM.
+- [X] Show the list of Programs.
+- [X] Change Program from the UI.
 - [ ] Rename a Program.
-- [ ] Store modifications to current Program.
-- [ ] Undo pending modifications.
+- [ ] Store / undo pending modifications.
 - [ ] Import a Program bank from a file.
 - [ ] Export a Program bank to a file.
 

--- a/jstation_derive/src/param_group.rs
+++ b/jstation_derive/src/param_group.rs
@@ -164,7 +164,7 @@ impl<'a> ToTokens for ParamGroup<'a> {
                     if let Err(err) = self.#field.set_raw(data) {
                         if err.is_inactive_param() {
                             // Don't propagate
-                            log::debug!("set_raw: {}", err);
+                            log::trace!("set_raw: {}", err);
                         } else {
                             return Err(err);
                         }

--- a/src/jstation/channel_voice.rs
+++ b/src/jstation/channel_voice.rs
@@ -1,4 +1,4 @@
-use crate::{jstation::ProgramNumber, midi};
+use crate::{jstation::ProgramId, midi};
 
 #[derive(Copy, Clone, Debug)]
 pub struct ChannelVoice {
@@ -9,7 +9,7 @@ pub struct ChannelVoice {
 #[derive(Copy, Clone, Debug)]
 pub enum Message {
     CC(midi::CC),
-    ProgramChange(ProgramNumber),
+    ProgramChange(ProgramId),
 }
 
 impl From<midi::ChannelVoice> for ChannelVoice {
@@ -17,7 +17,7 @@ impl From<midi::ChannelVoice> for ChannelVoice {
         use midi::channel_voice::Message::*;
         let msg = match cv.msg {
             CC(cc) => Message::CC(cc),
-            ProgramChange(prog_nb) => Message::ProgramChange(ProgramNumber::from(prog_nb)),
+            ProgramChange(midi_prog_nb) => Message::ProgramChange(ProgramId::from(midi_prog_nb)),
         };
 
         ChannelVoice { chan: cv.chan, msg }

--- a/src/jstation/data/mod.rs
+++ b/src/jstation/data/mod.rs
@@ -10,4 +10,4 @@ pub mod dsp;
 pub use dsp::Parameter;
 
 pub mod program;
-pub use program::{Program, ProgramBank, ProgramData, ProgramNumber};
+pub use program::{Program, ProgramData, ProgramId, ProgramNb, ProgramsBank};

--- a/src/jstation/error.rs
+++ b/src/jstation/error.rs
@@ -29,6 +29,9 @@ pub enum Error {
     #[error("Program name size {} out of range", .0)]
     ProgramNameOutOfRange(usize),
 
+    #[error("Unknown Programs Bank {}", .0)]
+    ProgramsBank(u8),
+
     #[error("Error Parsing MIDI message")]
     Parse,
 

--- a/src/jstation/interface.rs
+++ b/src/jstation/interface.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
 use crate::{
-    jstation::{parse_raw_midi_msg, procedure, sysex, Error, Message, Procedure, ProcedureBuilder},
+    jstation::{
+        self, parse_raw_midi_msg, procedure, sysex, Error, Message, Procedure, ProcedureBuilder,
+    },
     midi,
 };
 
@@ -65,11 +67,13 @@ impl Interface {
             .map_err(|err| Error::with_context("Program Update req.", err))
     }
 
-    pub fn change_program(&mut self, prog_nb: impl Into<midi::ProgramNumber>) -> Result<(), Error> {
-        self.send(&midi::ProgramChange::build_for(
-            prog_nb.into(),
-            self.cc_chan,
-        ))
+    pub fn change_program(&mut self, id: impl Into<midi::ProgramNumber>) -> Result<(), Error> {
+        self.send(&midi::ProgramChange::build_for(id.into(), self.cc_chan))
+    }
+
+    pub fn request_program(&mut self, id: jstation::ProgramId) -> Result<(), Error> {
+        self.send_sysex(procedure::OneProgramReq { id })
+            .map_err(|err| Error::with_context("Program req.", err))
     }
 
     fn send_sysex(&mut self, proc: impl ProcedureBuilder) -> Result<(), Error> {

--- a/src/jstation/mod.rs
+++ b/src/jstation/mod.rs
@@ -2,7 +2,7 @@ pub mod channel_voice;
 pub use channel_voice::ChannelVoice;
 
 pub mod data;
-pub use data::{CCParameter, Parameter, Program, ProgramNumber};
+pub use data::{CCParameter, Parameter, Program, ProgramId, ProgramNb, ProgramsBank};
 
 mod error;
 pub use error::Error;
@@ -13,7 +13,7 @@ pub use interface::{Interface, Listener};
 mod sysex;
 pub use sysex::{
     take_split_bytes_bool, take_split_bytes_chan, take_split_bytes_len, take_split_bytes_u16,
-    take_split_bytes_u8, BufferBuilder,
+    take_split_bytes_u8, take_u8, BufferBuilder,
 };
 
 pub mod procedure;

--- a/src/jstation/procedure/mod.rs
+++ b/src/jstation/procedure/mod.rs
@@ -89,4 +89,5 @@ declare_procs!(
     program_indices: ProgramIndicesReq, ProgramIndicesResp;
     program_update: ProgramUpdateReq, ProgramUpdateResp;
     who_am_i: WhoAmIReq, WhoAmIResp;
+    result: ToMessageResp;
 );

--- a/src/jstation/procedure/result.rs
+++ b/src/jstation/procedure/result.rs
@@ -1,0 +1,56 @@
+use std::fmt;
+
+use crate::jstation::{
+    split_bytes, take_split_bytes_u8, BufferBuilder, ProcedureBuilder
+};
+
+#[derive(Debug)]
+pub struct ToMessageResp {
+    pub req_proc: u8,
+    pub code: u8,
+}
+
+impl ProcedureBuilder for ToMessageResp {
+    const ID: u8 = 0x7f;
+    const VERSION: u8 = 1;
+
+    fn push_fixed_size_data(&self, buffer: &mut BufferBuilder) {
+        buffer.push_fixed_size_data(
+            split_bytes::from_u8(self.req_proc).into_iter()
+            .chain(split_bytes::from_u8(self.code).into_iter())
+        );
+    }
+}
+
+impl ToMessageResp {
+    pub fn parse<'i>(input: &'i [u8], checksum: &mut u8) -> nom::IResult<&'i [u8], ToMessageResp> {
+        let (i, req_proc) = take_split_bytes_u8(input, checksum)?;
+        let (i, code) = take_split_bytes_u8(i, checksum)?;
+
+        Ok((i, ToMessageResp { req_proc, code }))
+    }
+}
+
+impl fmt::Display for ToMessageResp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!("Response to procedure x{:02x}: ", self.req_proc))?;
+
+        let msg = match self.code {
+            0 => "OK",
+            1 => "Unknown Procedure Id",
+            2 => "Invalid Procedure Version",
+            3 => "Sysex Message Checksum Error",
+            4 => "Sysex Request Wrong Size",
+            5 => "MIDI Overrun Error",
+            6 => "Invalid Program Number",
+            7 => "Invalid User Program Number",
+            8 => "Invalid Bank Number",
+            9 => "Wrong Data Count",
+           10 => "Unknown OS Command",
+           11 => "Wrong Mode for OS Command",
+           other => return f.write_fmt(format_args!("code {other}")),
+        };
+
+        f.write_str(msg)
+    }
+}

--- a/src/jstation/sysex.rs
+++ b/src/jstation/sysex.rs
@@ -114,6 +114,14 @@ pub fn parse(input: &[u8]) -> IResult<&[u8], Message> {
     ))
 }
 
+pub fn take_u8<'i>(i: &'i [u8], checksum: &mut u8) -> IResult<&'i [u8], u8> {
+    let (i, bytes) = take(1usize)(i)?;
+    let byte = bytes[0];
+    *checksum ^= byte;
+
+    Ok((i, byte))
+}
+
 pub fn take_split_bytes_bool<'i>(i: &'i [u8], checksum: &mut u8) -> IResult<&'i [u8], bool> {
     let (i, bytes) = take(2usize)(i)?;
     *checksum = *checksum ^ bytes[0] ^ bytes[1];

--- a/src/ui/jstation.rs
+++ b/src/ui/jstation.rs
@@ -48,8 +48,12 @@ impl Interface {
         self.iface.program_update_req()
     }
 
-    pub fn change_program(&mut self, prog_nb: impl Into<midi::ProgramNumber>) -> Result<(), Error> {
-        self.iface.change_program(prog_nb)
+    pub fn change_program(&mut self, id: impl Into<midi::ProgramNumber>) -> Result<(), Error> {
+        self.iface.change_program(id)
+    }
+
+    pub fn request_program(&mut self, id: jstation::ProgramId) -> Result<(), Error> {
+        self.iface.request_program(id)
     }
 
     pub fn send_cc(&mut self, cc: midi::CC) -> Result<(), Error> {

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -3,6 +3,7 @@ use iced::{
     Background, Color,
 };
 
+#[derive(Clone, Copy)]
 pub enum Button {
     Default,
     ModalClose,

--- a/src/ui/widget.rs
+++ b/src/ui/widget.rs
@@ -12,6 +12,9 @@ use iced::{
 use crate::jstation::data::{BoolParameter, DiscreteParameter, Normal};
 use crate::ui::style;
 
+pub const DEFAULT_DSP_WIDTH: Length = Length::Units(622);
+pub const DSP_PROGRAM_SPACING: Length = Length::Units(10);
+
 pub fn button<'a, Message>(title: &str) -> Button<'a, Message, iced::Renderer> {
     Button::new(text(title).size(15)).style(style::Button::Default.into())
 }
@@ -28,6 +31,7 @@ where
     Checkbox::new(is_checked, title, f)
         .size(16)
         .text_size(15)
+        .spacing(6)
         .style(style::Checkbox)
 }
 
@@ -54,7 +58,7 @@ where
     Message: 'a,
 {
     container(row![title_area.width(Length::Units(270)), element.into()].padding(8))
-        .width(Length::Units(622))
+        .width(DEFAULT_DSP_WIDTH)
         .style(style::DspContainer)
 }
 


### PR DESCRIPTION
The new pick list gives access to user and factory Programs Banks. User programs are automatically downloaded from the device when the J-Station is identified. Factory programs are downloaded on demand, either after a user selection from the programs list in Factory mode or when rotating the data button on the device (the factory programs appear with a dot on the digital display).

Note that this feature was not implemented in gstation-edit.