### PR TITLE
Implement store and undo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ While it is usable to control a J-Station, this application is a work in progres
 - [X] Show the list of Programs.
 - [X] Change Program from the UI.
 - [ ] Rename a Program.
-- [ ] Store / undo pending modifications.
+- [X] Store / undo pending modifications.
 - [ ] Import a Program bank from a file.
 - [ ] Export a Program bank to a file.
 

--- a/jstation_derive/src/boolean.rs
+++ b/jstation_derive/src/boolean.rs
@@ -91,6 +91,18 @@ impl<'a> ToTokens for Boolean<'a> {
                             data_bool != self.0
                         }
                     }
+
+                    #[inline]
+                    fn store(&mut self, data: &mut crate::jstation::ProgramData) {
+                        use crate::jstation::data::BoolParameter;
+                        use crate::jstation::data::ParameterNumber;
+                        const PARAM_NB: ParameterNumber = ParameterNumber::new(#param_nb);
+
+                        // Safety: `ParameterNb` is guaranteed to be in the range `(0..PARAM_COUNT)`
+                        unsafe {
+                            *data.buf_mut().get_unchecked_mut(PARAM_NB.as_usize()) = self.raw_value();
+                        }
+                    }
                 }
             });
         }

--- a/jstation_derive/src/const_range.rs
+++ b/jstation_derive/src/const_range.rs
@@ -225,6 +225,17 @@ impl<'a> ToTokens for ConstRange<'a> {
                             *data.buf().get_unchecked(PARAM_NB.as_usize()) != self.0
                         }
                     }
+
+                    #[inline]
+                    fn store(&mut self, data: &mut crate::jstation::ProgramData) {
+                        use crate::jstation::data::ParameterNumber;
+                        const PARAM_NB: ParameterNumber = ParameterNumber::new(#param_nb);
+
+                        // Safety: `ParameterNb` is guaranteed to be in the range `(0..PARAM_COUNT)`
+                        unsafe {
+                            *data.buf_mut().get_unchecked_mut(PARAM_NB.as_usize()) = self.0;
+                        }
+                    }
                 }
             });
         }

--- a/jstation_derive/src/param.rs
+++ b/jstation_derive/src/param.rs
@@ -76,7 +76,7 @@ impl<'a> Param<'a> {
         self.base().cc_nb
     }
 
-    pub fn param_nb(&self) -> Option<usize> {
+    pub fn param_nb(&self) -> Option<u8> {
         self.base().param_nb
     }
 
@@ -91,7 +91,7 @@ impl<'a> Param<'a> {
 pub struct ParamBase<'a> {
     pub field: &'a Field,
     pub name: String,
-    pub param_nb: Option<usize>,
+    pub param_nb: Option<u8>,
     pub cc_nb: Option<u8>,
 }
 
@@ -108,7 +108,7 @@ impl<'a> ParamBase<'a> {
     pub fn have_arg(&mut self, arg: Arg) {
         let name = arg.name.to_string();
         match name.as_str() {
-            "param_nb" => self.param_nb = Some(arg.u8_or_abort(self.field) as usize),
+            "param_nb" => self.param_nb = Some(arg.u8_or_abort(self.field)),
             "cc_nb" => self.cc_nb = Some(arg.u8_or_abort(self.field)),
             other => {
                 abort!(

--- a/jstation_derive/src/param_group.rs
+++ b/jstation_derive/src/param_group.rs
@@ -71,9 +71,9 @@ impl<'a> ToTokens for ParamGroup<'a> {
                     #( #param_enum(#param_enum), )*
                 }
 
-                impl From<Parameter> for crate::jstation::Parameter {
+                impl From<Parameter> for crate::jstation::dsp::Parameter {
                     fn from(param: Parameter) -> Self {
-                        crate::jstation::Parameter::#group_name(param)
+                        crate::jstation::dsp::Parameter::#group_name(param)
                     }
                 }
 
@@ -189,7 +189,7 @@ impl<'a> ToTokens for ParamGroup<'a> {
             });
 
             tokens.extend(quote! {
-                impl crate::jstation::data::RawParameter for #group_name {
+                impl crate::jstation::data::RawParameterSetter for #group_name {
                     fn set_raw(
                         &mut self,
                         data: &[crate::jstation::data::RawValue]

--- a/src/jstation/data/dsp/compressor.rs
+++ b/src/jstation/data/dsp/compressor.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::jstation::data::DiscreteParameter;
+use crate::jstation::data::BaseParameter;
 use jstation_derive::ParameterSetter;
 
 #[derive(Clone, Copy, Debug, Default, ParameterSetter)]
@@ -19,11 +19,11 @@ pub struct Compressor {
 
 impl fmt::Display for Threshold {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let raw_value = self.raw_value().unwrap().as_u8();
+        let raw_value = self.raw_value().as_u8();
 
         // Don't display `-` if value is 0.
         let db_value = if raw_value > 0 {
-            -1.0 * (self.raw_value().unwrap().as_u8() as f32)
+            -1.0 * (raw_value as f32)
         } else {
             0.0
         };
@@ -45,7 +45,7 @@ impl fmt::Display for Ratio {
 
 impl fmt::Display for Gain {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let db_value = self.raw_value().unwrap().as_u8() as f32;
+        let db_value = self.raw_value().as_u8() as f32;
 
         fmt::Display::fmt(&db_value, f)?;
         f.write_str(" dB")

--- a/src/jstation/data/dsp/compressor.rs
+++ b/src/jstation/data/dsp/compressor.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::jstation::data::BaseParameter;
+use crate::jstation::data::DiscreteParameter;
 use jstation_derive::ParameterSetter;
 
 #[derive(Clone, Copy, Debug, Default, ParameterSetter)]

--- a/src/jstation/data/dsp/delay.rs
+++ b/src/jstation/data/dsp/delay.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::jstation::data::DiscreteParameter;
+use crate::jstation::data::BaseParameter;
 use jstation_derive::ParameterSetter;
 
 #[derive(Clone, Copy, Debug, Default, ParameterSetter)]
@@ -25,7 +25,7 @@ const TYPE_NAMES: [&str; 4] = ["Mono", "Analog", "Pong", "Analog Pong"];
 
 impl fmt::Display for TimeCourse {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let value = self.raw_value().unwrap().as_u8();
+        let value = self.raw_value().as_u8();
         if value > 9 {
             f.write_fmt(format_args!("{:0.1} s", value as f32 / 10.0))
         } else {
@@ -37,7 +37,7 @@ impl fmt::Display for TimeCourse {
 
 impl fmt::Display for TimeFine {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self.raw_value().unwrap().as_u8(), f)?;
+        fmt::Display::fmt(&self.raw_value().as_u8(), f)?;
         f.write_str(" ms")
     }
 }

--- a/src/jstation/data/dsp/delay.rs
+++ b/src/jstation/data/dsp/delay.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::jstation::data::BaseParameter;
+use crate::jstation::data::DiscreteParameter;
 use jstation_derive::ParameterSetter;
 
 #[derive(Clone, Copy, Debug, Default, ParameterSetter)]

--- a/src/jstation/data/dsp/effect.rs
+++ b/src/jstation/data/dsp/effect.rs
@@ -3,8 +3,7 @@ use std::fmt;
 use jstation_derive::ParameterSetter;
 
 use crate::jstation::data::{
-    BaseParameter, DiscreteParameter, DiscreteRange, Normal, RawValue, VariableRange,
-    VariableRangeParameter,
+    DiscreteParameter, DiscreteRange, Normal, RawValue, VariableRange, VariableRangeParameter,
 };
 
 #[derive(Clone, Copy, Debug, Default, ParameterSetter)]

--- a/src/jstation/data/dsp/effect.rs
+++ b/src/jstation/data/dsp/effect.rs
@@ -3,7 +3,8 @@ use std::fmt;
 use jstation_derive::ParameterSetter;
 
 use crate::jstation::data::{
-    DiscreteParameter, DiscreteRange, Normal, RawValue, VariableRange, VariableRangeParameter,
+    BaseParameter, DiscreteParameter, DiscreteRange, Normal, RawValue, VariableRange,
+    VariableRangeParameter,
 };
 
 #[derive(Clone, Copy, Debug, Default, ParameterSetter)]
@@ -50,7 +51,7 @@ pub enum Discriminant {
 impl From<Type> for Discriminant {
     fn from(typ: Type) -> Self {
         use Discriminant::*;
-        match typ.raw_value().unwrap().as_u8() {
+        match typ.raw_value().as_u8() {
             0 => Chorus,
             1 => Flanger,
             2 => Phaser,
@@ -128,10 +129,6 @@ impl DiscreteParameter for Speed {
         Some(range.try_normalize(self.value).unwrap())
     }
 
-    fn raw_value(self) -> Option<RawValue> {
-        Some(self.value)
-    }
-
     fn reset(&mut self) -> Option<Self> {
         let default = RawValue::new(match self.discr {
             Discriminant::PitchDetune => 24,
@@ -162,10 +159,10 @@ impl Speed {
 impl fmt::Display for Speed {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let value = match self.discr {
-            Discriminant::AutoWah => self.raw_value().unwrap().as_u8() as i32,
+            Discriminant::AutoWah => self.raw_value().as_u8() as i32,
             Discriminant::PitchDetune => {
                 // -24 to +24 semitones.
-                self.raw_value().unwrap().as_u8() as i32 - 24i32
+                self.raw_value().as_u8() as i32 - 24i32
             }
             _ => self.range().unwrap().to_cents(self.value).unwrap() as i32,
         };
@@ -236,10 +233,6 @@ impl DiscreteParameter for Depth {
         Some(range.try_normalize(self.value).unwrap())
     }
 
-    fn raw_value(self) -> Option<RawValue> {
-        Some(self.value)
-    }
-
     fn reset(&mut self) -> Option<Self> {
         let default = RawValue::new(match self.discr {
             Discriminant::PitchDetune => 30,
@@ -261,7 +254,7 @@ impl fmt::Display for Depth {
         let value = match self.discr {
             Discriminant::PitchDetune => {
                 // -30 to +30 cents.
-                self.raw_value().unwrap().as_u8() as i32 - 30i32
+                self.raw_value().as_u8() as i32 - 30i32
             }
             _ => self.range().unwrap().to_cents(self.value).unwrap() as i32,
         };
@@ -303,14 +296,6 @@ impl DiscreteParameter for Regen {
     fn normal(self) -> Option<Normal> {
         let range = self.range()?;
         Some(range.try_normalize(self.value).unwrap())
-    }
-
-    fn raw_value(self) -> Option<RawValue> {
-        if !self.is_active() {
-            return None;
-        }
-
-        Some(self.value)
     }
 
     fn reset(&mut self) -> Option<Self> {

--- a/src/jstation/data/dsp/mod.rs
+++ b/src/jstation/data/dsp/mod.rs
@@ -71,6 +71,21 @@ impl ProgramParameter for Dsp {
             || self.reverb.has_changed(original)
             || self.name.as_str() != original.name()
     }
+
+    fn store(&mut self, data: &mut ProgramData) {
+        self.compressor.store(data);
+        self.wah_expr.store(data);
+        self.amp.store(data);
+        self.cabinet.store(data);
+        self.noise_gate.store(data);
+        self.effect.store(data);
+        self.delay.store(data);
+        self.reverb.store(data);
+
+        // FIXME find a solution to reduce String clones
+        data.store_name(&self.name);
+        self.name = data.name().to_string();
+    }
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/src/jstation/data/dsp/mod.rs
+++ b/src/jstation/data/dsp/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     jstation::{
-        data::{CCParameter, CCParameterSetter, ParameterSetter, RawParameterSetter, RawValue},
+        data::{CCParameter, CCParameterSetter, ParameterSetter, ProgramData, ProgramParameter},
         Error,
     },
     midi,
@@ -35,6 +35,7 @@ pub use wah_expr::WahExpr;
 
 #[derive(Debug, Default)]
 pub struct Dsp {
+    pub name: String,
     pub amp: Amp,
     pub cabinet: Cabinet,
     pub compressor: Compressor,
@@ -46,16 +47,29 @@ pub struct Dsp {
     pub utility_settings: UtilitySettings,
 }
 
-impl RawParameterSetter for Dsp {
-    fn set_raw(&mut self, data: &[RawValue]) -> Result<(), Error> {
-        self.compressor.set_raw(data)?;
-        self.wah_expr.set_raw(data)?;
-        self.amp.set_raw(data)?;
-        self.cabinet.set_raw(data)?;
-        self.noise_gate.set_raw(data)?;
-        self.effect.set_raw(data)?;
-        self.delay.set_raw(data)?;
-        self.reverb.set_raw(data)
+impl ProgramParameter for Dsp {
+    fn set_from(&mut self, data: &ProgramData) -> Result<(), Error> {
+        self.name = data.name().to_string();
+        self.compressor.set_from(data)?;
+        self.wah_expr.set_from(data)?;
+        self.amp.set_from(data)?;
+        self.cabinet.set_from(data)?;
+        self.noise_gate.set_from(data)?;
+        self.effect.set_from(data)?;
+        self.delay.set_from(data)?;
+        self.reverb.set_from(data)
+    }
+
+    fn has_changed(&self, original: &ProgramData) -> bool {
+        self.compressor.has_changed(original)
+            || self.wah_expr.has_changed(original)
+            || self.amp.has_changed(original)
+            || self.cabinet.has_changed(original)
+            || self.noise_gate.has_changed(original)
+            || self.effect.has_changed(original)
+            || self.delay.has_changed(original)
+            || self.reverb.has_changed(original)
+            || self.name.as_str() != original.name()
     }
 }
 

--- a/src/jstation/data/dsp/mod.rs
+++ b/src/jstation/data/dsp/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     jstation::{
-        data::{CCParameter, CCParameterSetter, ParameterSetter, RawValue},
+        data::{CCParameter, CCParameterSetter, ParameterSetter, RawParameterSetter, RawValue},
         Error,
     },
     midi,
@@ -46,10 +46,8 @@ pub struct Dsp {
     pub utility_settings: UtilitySettings,
 }
 
-impl Dsp {
-    pub fn set_raw(&mut self, data: &[RawValue]) -> Result<(), Error> {
-        use crate::jstation::data::RawParameter;
-
+impl RawParameterSetter for Dsp {
+    fn set_raw(&mut self, data: &[RawValue]) -> Result<(), Error> {
         self.compressor.set_raw(data)?;
         self.wah_expr.set_raw(data)?;
         self.amp.set_raw(data)?;

--- a/src/jstation/data/mod.rs
+++ b/src/jstation/data/mod.rs
@@ -1,12 +1,12 @@
 #[macro_use]
 pub mod parameter;
 pub use parameter::{
-    BaseParameter, BoolParameter, CCParameter, CCParameterSetter, ConstRangeParameter,
-    DiscreteParameter, DiscreteRange, Normal, ParameterNumber, ParameterSetter, RawParameterSetter,
-    RawValue, VariableRange, VariableRangeParameter,
+    BoolParameter, CCParameter, CCParameterSetter, ConstRangeParameter, DiscreteParameter,
+    DiscreteRange, Normal, ParameterNumber, ParameterSetter, RawValue, VariableRange,
+    VariableRangeParameter,
 };
 
 pub mod dsp;
 
 pub mod program;
-pub use program::{Program, ProgramData, ProgramId, ProgramNb, ProgramsBank};
+pub use program::{Program, ProgramData, ProgramId, ProgramNb, ProgramParameter, ProgramsBank};

--- a/src/jstation/data/mod.rs
+++ b/src/jstation/data/mod.rs
@@ -1,13 +1,12 @@
 #[macro_use]
 pub mod parameter;
 pub use parameter::{
-    BoolParameter, CCParameter, CCParameterSetter, ConstRangeParameter, DiscreteParameter,
-    DiscreteRange, Normal, ParameterNumber, ParameterSetter, RawParameter, RawValue, VariableRange,
-    VariableRangeParameter,
+    BaseParameter, BoolParameter, CCParameter, CCParameterSetter, ConstRangeParameter,
+    DiscreteParameter, DiscreteRange, Normal, ParameterNumber, ParameterSetter, RawParameterSetter,
+    RawValue, VariableRange, VariableRangeParameter,
 };
 
 pub mod dsp;
-pub use dsp::Parameter;
 
 pub mod program;
 pub use program::{Program, ProgramData, ProgramId, ProgramNb, ProgramsBank};

--- a/src/jstation/data/parameter/boolean.rs
+++ b/src/jstation/data/parameter/boolean.rs
@@ -20,11 +20,7 @@ pub trait BoolParameter:
     }
 
     fn raw_value(self) -> RawValue {
-        RawValue::new(if self.into() {
-            0
-        } else {
-            RawValue::MAX.as_u8()
-        })
+        RawValue::new(u8::from(self.into()))
     }
 
     fn is_true(&self) -> bool {

--- a/src/jstation/data/parameter/boolean.rs
+++ b/src/jstation/data/parameter/boolean.rs
@@ -1,7 +1,14 @@
-use crate::jstation::data::{BaseParameter, RawValue};
+use crate::jstation::data::{ParameterSetter, RawValue};
 
 pub trait BoolParameter:
-    From<bool> + Into<bool> + BaseParameter + Default + Clone + Copy + Eq + PartialEq
+    From<bool>
+    + Into<bool>
+    + ParameterSetter<Parameter = Self>
+    + Clone
+    + Copy
+    + Default
+    + Eq
+    + PartialEq
 {
     const TRUE: Self;
     const FALSE: Self;
@@ -10,6 +17,14 @@ pub trait BoolParameter:
 
     fn from_raw(raw: RawValue) -> Self {
         (raw.as_u8() == 0).into()
+    }
+
+    fn raw_value(self) -> RawValue {
+        RawValue::new(if self.into() {
+            0
+        } else {
+            RawValue::MAX.as_u8()
+        })
     }
 
     fn is_true(&self) -> bool {

--- a/src/jstation/data/parameter/boolean.rs
+++ b/src/jstation/data/parameter/boolean.rs
@@ -1,14 +1,7 @@
-use crate::jstation::data::{ParameterSetter, RawValue};
+use crate::jstation::data::{BaseParameter, RawValue};
 
 pub trait BoolParameter:
-    From<bool>
-    + Into<bool>
-    + ParameterSetter<Parameter = Self>
-    + Default
-    + Clone
-    + Copy
-    + Eq
-    + PartialEq
+    From<bool> + Into<bool> + BaseParameter + Default + Clone + Copy + Eq + PartialEq
 {
     const TRUE: Self;
     const FALSE: Self;
@@ -17,10 +10,6 @@ pub trait BoolParameter:
 
     fn from_raw(raw: RawValue) -> Self {
         (raw.as_u8() == 0).into()
-    }
-
-    fn raw_value(self) -> RawValue {
-        RawValue::new(if self.into() { 0 } else { u8::MAX })
     }
 
     fn is_true(&self) -> bool {

--- a/src/jstation/data/parameter/discrete.rs
+++ b/src/jstation/data/parameter/discrete.rs
@@ -1,15 +1,21 @@
 use crate::jstation::{
-    data::{BaseParameter, Normal, RawValue},
+    data::{Normal, ParameterSetter, RawValue},
     Error,
 };
 use crate::midi;
 
-pub trait DiscreteParameter: BaseParameter + Clone + Copy {
+pub trait DiscreteParameter:
+    Into<RawValue> + ParameterSetter<Parameter = Self> + Clone + Copy
+{
     fn param_name(self) -> &'static str;
 
     fn normal_default(self) -> Option<Normal>;
 
     fn normal(self) -> Option<Normal>;
+
+    fn raw_value(self) -> RawValue {
+        self.into()
+    }
 
     /// Resets the parameter to its default value.
     fn reset(&mut self) -> Option<Self>;

--- a/src/jstation/data/parameter/discrete.rs
+++ b/src/jstation/data/parameter/discrete.rs
@@ -40,7 +40,11 @@ impl DiscreteRange {
     const ROUNDING: u32 = Self::SCALE / 2;
     const MAX_CC_SCALED: u32 = Self::MAX_CC_U32 * Self::SCALE;
 
-    /// Builds a new `DiscreteRange` from the provided value.
+    /// Builds a new `DiscreteRange` from the provided values.
+    ///
+    /// # Panic
+    ///
+    /// Panics if min >= max.
     pub const fn new(min: RawValue, max: RawValue) -> Self {
         let min = min.as_u8();
         let max = max.as_u8();

--- a/src/jstation/data/parameter/discrete.rs
+++ b/src/jstation/data/parameter/discrete.rs
@@ -1,17 +1,15 @@
 use crate::jstation::{
-    data::{Normal, ParameterSetter, RawValue},
+    data::{BaseParameter, Normal, RawValue},
     Error,
 };
 use crate::midi;
 
-pub trait DiscreteParameter: ParameterSetter<Parameter = Self> + Clone + Copy {
+pub trait DiscreteParameter: BaseParameter + Clone + Copy {
     fn param_name(self) -> &'static str;
 
     fn normal_default(self) -> Option<Normal>;
 
     fn normal(self) -> Option<Normal>;
-
-    fn raw_value(self) -> Option<RawValue>;
 
     /// Resets the parameter to its default value.
     fn reset(&mut self) -> Option<Self>;

--- a/src/jstation/data/parameter/mod.rs
+++ b/src/jstation/data/parameter/mod.rs
@@ -11,7 +11,7 @@ mod normal;
 pub use normal::Normal;
 
 mod raw;
-pub use raw::{RawParameter, RawValue};
+pub use raw::{RawParameterSetter, RawValue};
 
 mod variable_range;
 pub use variable_range::{VariableRange, VariableRangeParameter};
@@ -20,6 +20,11 @@ use std::fmt;
 
 use crate::{jstation::Error, midi};
 
+pub trait BaseParameter: ParameterSetter<Parameter = Self> {
+    fn nb(self) -> Option<ParameterNumber>;
+    fn raw_value(self) -> RawValue;
+}
+
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
 pub struct ParameterNumber(u8);
 
@@ -27,6 +32,8 @@ impl ParameterNumber {
     pub const MAX: ParameterNumber = ParameterNumber(43);
 
     pub const fn new(nb: u8) -> Self {
+        assert!(nb <= Self::MAX.0);
+
         ParameterNumber(nb)
     }
 

--- a/src/jstation/data/parameter/mod.rs
+++ b/src/jstation/data/parameter/mod.rs
@@ -11,7 +11,7 @@ mod normal;
 pub use normal::Normal;
 
 mod raw;
-pub use raw::{RawParameterSetter, RawValue};
+pub use raw::RawValue;
 
 mod variable_range;
 pub use variable_range::{VariableRange, VariableRangeParameter};
@@ -19,11 +19,6 @@ pub use variable_range::{VariableRange, VariableRangeParameter};
 use std::fmt;
 
 use crate::{jstation::Error, midi};
-
-pub trait BaseParameter: ParameterSetter<Parameter = Self> {
-    fn nb(self) -> Option<ParameterNumber>;
-    fn raw_value(self) -> RawValue;
-}
 
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
 pub struct ParameterNumber(u8);
@@ -39,6 +34,10 @@ impl ParameterNumber {
 
     pub const fn as_u8(self) -> u8 {
         self.0
+    }
+
+    pub const fn as_usize(self) -> usize {
+        self.0 as usize
     }
 }
 

--- a/src/jstation/data/parameter/raw.rs
+++ b/src/jstation/data/parameter/raw.rs
@@ -1,11 +1,5 @@
-use std::fmt;
-
-use crate::jstation::Error;
 use crate::midi;
-
-pub trait RawParameterSetter {
-    fn set_raw(&mut self, data: &[RawValue]) -> Result<(), Error>;
-}
+use std::fmt;
 
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd)]
 pub struct RawValue(u8);

--- a/src/jstation/data/parameter/raw.rs
+++ b/src/jstation/data/parameter/raw.rs
@@ -1,8 +1,9 @@
 use std::fmt;
 
-use crate::{jstation::Error, midi};
+use crate::jstation::Error;
+use crate::midi;
 
-pub trait RawParameter {
+pub trait RawParameterSetter {
     fn set_raw(&mut self, data: &[RawValue]) -> Result<(), Error>;
 }
 

--- a/src/jstation/data/program.rs
+++ b/src/jstation/data/program.rs
@@ -246,6 +246,10 @@ impl ProgramsBank {
         matches!(self, ProgramsBank::User)
     }
 
+    pub fn is_factory(self) -> bool {
+        matches!(self, ProgramsBank::Factory)
+    }
+
     pub fn into_prog_id(self, nb: ProgramNb) -> ProgramId {
         use ProgramsBank::*;
         match self {
@@ -276,9 +280,9 @@ impl TryFrom<u8> for ProgramsBank {
 }
 
 impl From<ProgramsBank> for u8 {
-    fn from(progs_bank: ProgramsBank) -> Self {
+    fn from(bank: ProgramsBank) -> Self {
         use ProgramsBank::*;
-        match progs_bank {
+        match bank {
             User => ProgramsBank::USER,
             Factory => ProgramsBank::FACTORY,
         }
@@ -289,8 +293,8 @@ impl fmt::Display for ProgramsBank {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use ProgramsBank::*;
         f.write_str(match self {
-            User => "User",
-            Factory => "Factory",
+            User => "User Bank",
+            Factory => "Factory Bank",
         })
     }
 }
@@ -309,38 +313,38 @@ impl From<midi::ProgramNumber> for ProgramsBank {
 
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd)]
 pub struct ProgramId {
-    progs_bank: ProgramsBank,
+    bank: ProgramsBank,
     nb: ProgramNb,
 }
 
 impl ProgramId {
-    pub fn new(progs_bank: ProgramsBank, nb: ProgramNb) -> Self {
-        ProgramId { progs_bank, nb }
+    pub fn new(bank: ProgramsBank, nb: ProgramNb) -> Self {
+        ProgramId { bank, nb }
     }
 
     pub fn new_user(nb: ProgramNb) -> Self {
         ProgramId {
-            progs_bank: ProgramsBank::User,
+            bank: ProgramsBank::User,
             nb,
         }
     }
 
     pub fn new_factory(nb: ProgramNb) -> Self {
         ProgramId {
-            progs_bank: ProgramsBank::Factory,
+            bank: ProgramsBank::Factory,
             nb,
         }
     }
 
-    pub fn try_from_raw(progs_bank: u8, nb: u8) -> Result<Self, Error> {
+    pub fn try_from_raw(bank: u8, nb: u8) -> Result<Self, Error> {
         Ok(ProgramId {
-            progs_bank: ProgramsBank::try_from(progs_bank)?,
+            bank: ProgramsBank::try_from(bank)?,
             nb: ProgramNb::try_from(nb)?,
         })
     }
 
-    pub fn progs_bank(self) -> ProgramsBank {
-        self.progs_bank
+    pub fn bank(self) -> ProgramsBank {
+        self.bank
     }
 
     pub fn nb(self) -> ProgramNb {
@@ -351,7 +355,7 @@ impl ProgramId {
 impl From<midi::ProgramNumber> for ProgramId {
     fn from(midi_prog_nb: midi::ProgramNumber) -> Self {
         ProgramId {
-            progs_bank: ProgramsBank::from(midi_prog_nb),
+            bank: ProgramsBank::from(midi_prog_nb),
             nb: ProgramNb::from(midi_prog_nb),
         }
     }
@@ -359,13 +363,13 @@ impl From<midi::ProgramNumber> for ProgramId {
 
 impl From<ProgramId> for midi::ProgramNumber {
     fn from(id: ProgramId) -> Self {
-        midi::ProgramNumber::from(id.nb.0 + id.progs_bank.midi_offset())
+        midi::ProgramNumber::from(id.nb.0 + id.bank.midi_offset())
     }
 }
 
 impl fmt::Display for ProgramId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&self.nb, f)?;
-        f.write_fmt(format_args!("({})", self.progs_bank))
+        f.write_fmt(format_args!("({})", self.bank))
     }
 }

--- a/src/jstation/interface.rs
+++ b/src/jstation/interface.rs
@@ -85,6 +85,8 @@ impl Interface {
     pub fn store_program(&mut self, prog: &Program) -> Result<(), Error> {
         // Note: gstation-edit also sends a ProgramUpdateResp, but the
         // result seems to be the same with only OneProgramResp.
+        // Or is it needed to change program's name?
+
         self.send_sysex(procedure::OneProgramResp::from(prog))
             .map_err(|err| Error::with_context("Store One Program resp.", err))
     }

--- a/src/jstation/interface.rs
+++ b/src/jstation/interface.rs
@@ -76,6 +76,11 @@ impl Interface {
             .map_err(|err| Error::with_context("Program req.", err))
     }
 
+    pub fn reload_program(&mut self) -> Result<(), Error> {
+        self.send_sysex(procedure::ReloadProgramReq)
+            .map_err(|err| Error::with_context("Reload Program req.", err))
+    }
+
     fn send_sysex(&mut self, proc: impl ProcedureBuilder) -> Result<(), Error> {
         self.send(&proc.build_for(self.sysex_chan))
     }

--- a/src/jstation/interface.rs
+++ b/src/jstation/interface.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use crate::{
     jstation::{
         self, parse_raw_midi_msg, procedure, sysex, Error, Message, Procedure, ProcedureBuilder,
+        Program,
     },
     midi,
 };
@@ -81,7 +82,14 @@ impl Interface {
             .map_err(|err| Error::with_context("Reload Program req.", err))
     }
 
-    fn send_sysex(&mut self, proc: impl ProcedureBuilder) -> Result<(), Error> {
+    pub fn store_program(&mut self, prog: &Program) -> Result<(), Error> {
+        // Note: gstation-edit also sends a ProgramUpdateResp, but the
+        // result seems to be the same with only OneProgramResp.
+        self.send_sysex(procedure::OneProgramResp::from(prog))
+            .map_err(|err| Error::with_context("Store One Program resp.", err))
+    }
+
+    fn send_sysex<'a>(&mut self, proc: impl 'a + ProcedureBuilder) -> Result<(), Error> {
         self.send(&proc.build_for(self.sysex_chan))
     }
 

--- a/src/jstation/mod.rs
+++ b/src/jstation/mod.rs
@@ -2,7 +2,7 @@ pub mod channel_voice;
 pub use channel_voice::ChannelVoice;
 
 pub mod data;
-pub use data::{CCParameter, Parameter, Program, ProgramId, ProgramNb, ProgramsBank};
+pub use data::{dsp, CCParameter, Program, ProgramId, ProgramNb, ProgramsBank};
 
 mod error;
 pub use error::Error;

--- a/src/jstation/mod.rs
+++ b/src/jstation/mod.rs
@@ -2,7 +2,7 @@ pub mod channel_voice;
 pub use channel_voice::ChannelVoice;
 
 pub mod data;
-pub use data::{dsp, CCParameter, Program, ProgramId, ProgramNb, ProgramsBank};
+pub use data::{dsp, CCParameter, Program, ProgramData, ProgramId, ProgramNb, ProgramsBank};
 
 mod error;
 pub use error::Error;

--- a/src/jstation/procedure/mod.rs
+++ b/src/jstation/procedure/mod.rs
@@ -88,6 +88,7 @@ declare_procs!(
     one_program: OneProgramReq, OneProgramResp;
     program_indices: ProgramIndicesReq, ProgramIndicesResp;
     program_update: ProgramUpdateReq, ProgramUpdateResp;
+    reload_program: ReloadProgramReq;
     who_am_i: WhoAmIReq, WhoAmIResp;
     result: ToMessageResp;
 );

--- a/src/jstation/procedure/mod.rs
+++ b/src/jstation/procedure/mod.rs
@@ -9,12 +9,12 @@ use crate::{
     midi,
 };
 
-//pub const MERGE_RESPONSE: u8 = 0x7f;
-
 pub trait ProcedureBuilder {
     const ID: u8;
     const VERSION: u8;
 
+    // FIXME these are error-prone because the user must use the proper
+    // BufferBuilder method in the functions.
     fn push_fixed_size_data(&self, _buffer: &mut sysex::BufferBuilder) {}
     fn push_variable_size_data(&self, _buffer: &mut sysex::BufferBuilder) {}
 
@@ -92,3 +92,6 @@ declare_procs!(
     who_am_i: WhoAmIReq, WhoAmIResp;
     result: ToMessageResp;
 );
+
+pub use one_program::OneProgramRefResp;
+pub use program_update::ProgramUpdateRefResp;

--- a/src/jstation/procedure/one_program.rs
+++ b/src/jstation/procedure/one_program.rs
@@ -56,7 +56,7 @@ impl ProcedureBuilder for OneProgramResp {
     }
 
     fn push_variable_size_data(&self, buffer: &mut crate::jstation::sysex::BufferBuilder) {
-        let mut buf: Vec<u8> = self.prog.data().iter().map(Into::into).collect();
+        let mut buf: Vec<u8> = self.prog.data().buf().iter().map(Into::into).collect();
         buf.extend(self.prog.name().as_bytes());
         // Terminal 0 for name
         buf.push(0x00);

--- a/src/jstation/procedure/one_program.rs
+++ b/src/jstation/procedure/one_program.rs
@@ -15,18 +15,19 @@ impl ProcedureBuilder for OneProgramReq {
     const VERSION: u8 = 1;
 
     fn push_fixed_size_data(&self, buffer: &mut BufferBuilder) {
-        buffer.push_fixed_size_data(
-            [self.id.progs_bank().into(), self.id.nb().into()].into_iter()
-        );
+        buffer.push_fixed_size_data([
+            self.id.bank().into(),
+            self.id.nb().into(),
+        ].into_iter());
     }
 }
 
 impl OneProgramReq {
     pub fn parse<'i>(input: &'i [u8], checksum: &mut u8) -> IResult<&'i [u8], OneProgramReq> {
-        let (i, progs_bank) = take_u8(input, checksum)?;
+        let (i, bank) = take_u8(input, checksum)?;
         let (i, nb) = take_u8(i, checksum)?;
 
-        let id = ProgramId::try_from_raw(progs_bank, nb).map_err(|err| {
+        let id = ProgramId::try_from_raw(bank, nb).map_err(|err| {
             log::error!("OneProgramReq: {err}");
 
             nom::Err::Failure(nom::error::Error::new(
@@ -72,7 +73,7 @@ impl<'a> ProcedureBuilder for OneProgramRefResp<'a> {
 
     fn push_fixed_size_data(&self, buffer: &mut BufferBuilder) {
         buffer.push_fixed_size_data([
-            self.0.id().progs_bank().into(),
+            self.0.id().bank().into(),
             self.0.id().nb().into(),
         ].into_iter());
     }
@@ -85,10 +86,10 @@ impl<'a> ProcedureBuilder for OneProgramRefResp<'a> {
 
 impl OneProgramResp {
     pub fn parse<'i>(input: &'i [u8], checksum: &mut u8) -> IResult<&'i [u8], OneProgramResp> {
-        let (i, progs_bank) = take_split_bytes_u8(input, checksum)?;
+        let (i, bank) = take_split_bytes_u8(input, checksum)?;
         let (i, nb) = take_split_bytes_u8(i, checksum)?;
 
-        let id = ProgramId::try_from_raw(progs_bank, nb).map_err(|err| {
+        let id = ProgramId::try_from_raw(bank, nb).map_err(|err| {
             log::error!("OneProgramResp: {err}");
 
             nom::Err::Failure(nom::error::Error::new(

--- a/src/jstation/procedure/reload_program.rs
+++ b/src/jstation/procedure/reload_program.rs
@@ -1,0 +1,17 @@
+use nom::IResult;
+
+use crate::jstation::ProcedureBuilder;
+
+#[derive(Debug)]
+pub struct ReloadProgramReq;
+
+impl ProcedureBuilder for ReloadProgramReq {
+    const ID: u8 = 0x20;
+    const VERSION: u8 = 1;
+}
+
+impl ReloadProgramReq {
+    pub fn parse<'i>(input: &'i [u8], _checksum: &mut u8) -> IResult<&'i [u8], ReloadProgramReq> {
+        Ok((input, ReloadProgramReq))
+    }
+}

--- a/src/jstation/procedure/result.rs
+++ b/src/jstation/procedure/result.rs
@@ -1,12 +1,11 @@
-use crate::jstation::{
-    split_bytes, take_split_bytes_u8, BufferBuilder, ProcedureBuilder
-};
+use crate::jstation::{take_split_bytes_u8, BufferBuilder, ProcedureBuilder};
 
 #[derive(Debug)]
 pub struct ToMessageResp {
     pub res: Result<u8, Error>,
 }
 
+// FIXME remove if not needed
 impl ProcedureBuilder for ToMessageResp {
     const ID: u8 = 0x7f;
     const VERSION: u8 = 1;
@@ -17,10 +16,7 @@ impl ProcedureBuilder for ToMessageResp {
             Err(err) => err.into(),
         };
 
-        buffer.push_fixed_size_data(
-            split_bytes::from_u8(req_proc).into_iter()
-            .chain(split_bytes::from_u8(code).into_iter())
-        );
+        buffer.push_fixed_size_data([req_proc ,code].into_iter());
     }
 }
 

--- a/src/jstation/procedure/result.rs
+++ b/src/jstation/procedure/result.rs
@@ -1,13 +1,10 @@
-use std::fmt;
-
 use crate::jstation::{
     split_bytes, take_split_bytes_u8, BufferBuilder, ProcedureBuilder
 };
 
 #[derive(Debug)]
 pub struct ToMessageResp {
-    pub req_proc: u8,
-    pub code: u8,
+    pub res: Result<u8, Error>,
 }
 
 impl ProcedureBuilder for ToMessageResp {
@@ -15,9 +12,14 @@ impl ProcedureBuilder for ToMessageResp {
     const VERSION: u8 = 1;
 
     fn push_fixed_size_data(&self, buffer: &mut BufferBuilder) {
+        let (req_proc, code) = match self.res {
+            Ok(req_proc) => (req_proc, 0),
+            Err(err) => err.into(),
+        };
+
         buffer.push_fixed_size_data(
-            split_bytes::from_u8(self.req_proc).into_iter()
-            .chain(split_bytes::from_u8(self.code).into_iter())
+            split_bytes::from_u8(req_proc).into_iter()
+            .chain(split_bytes::from_u8(code).into_iter())
         );
     }
 }
@@ -27,30 +29,77 @@ impl ToMessageResp {
         let (i, req_proc) = take_split_bytes_u8(input, checksum)?;
         let (i, code) = take_split_bytes_u8(i, checksum)?;
 
-        Ok((i, ToMessageResp { req_proc, code }))
+        Ok((i, ToMessageResp { res: try_from(req_proc, code) }))
     }
 }
 
-impl fmt::Display for ToMessageResp {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_fmt(format_args!("Response to procedure x{:02x}: ", self.req_proc))?;
 
-        let msg = match self.code {
-            0 => "OK",
-            1 => "Unknown Procedure Id",
-            2 => "Invalid Procedure Version",
-            3 => "Sysex Message Checksum Error",
-            4 => "Sysex Request Wrong Size",
-            5 => "MIDI Overrun Error",
-            6 => "Invalid Program Number",
-            7 => "Invalid User Program Number",
-            8 => "Invalid Bank Number",
-            9 => "Wrong Data Count",
-           10 => "Unknown OS Command",
-           11 => "Wrong Mode for OS Command",
-           other => return f.write_fmt(format_args!("code {other}")),
-        };
+#[derive(Clone, Copy, Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Unknown Procedure Id x{:02x}", .req_proc)]
+    ProcedureId { req_proc: u8 },
+    #[error("Invalid Procedure Version for x{:02x}", .req_proc)]
+    ProcedureVersion { req_proc: u8 },
+    #[error("Sysex Message Checksum Error for x{:02x}", .req_proc)]
+    SysexChecksum { req_proc: u8 },
+    #[error("Sysex Request Wrong Size for x{:02x}", .req_proc)]
+    SysexSize { req_proc: u8 },
+    #[error("MIDI Overrun Error for x{:02x}", .req_proc)]
+    MIDIOverrun { req_proc: u8 },
+    #[error("Invalid Program Number for x{:02x}", .req_proc)]
+    ProgramNumber { req_proc: u8 },
+    #[error("Invalid User Program Number for x{:02x}", .req_proc)]
+    UserProgramNumber { req_proc: u8 },
+    #[error("Invalid Bank Number for x{:02x}", .req_proc)]
+    BankNumber { req_proc: u8 },
+    #[error("Wrong Data Count for x{:02x}", .req_proc)]
+    DataCount { req_proc: u8 },
+    #[error("Unknown OS Command for x{:02x}", .req_proc)]
+    OSCommand { req_proc: u8 },
+    #[error("Wrong Mode for OS Command for x{:02x}", .req_proc)]
+    OSCommandMode { req_proc: u8 },
+    #[error("Unknown error {} for x{:02x}", .code, .req_proc)]
+    Unknown { req_proc: u8, code: u8 },
+}
 
-        f.write_str(msg)
+// FIXME these should be generated from a single definition
+
+impl From<Error> for (u8, u8) {
+    fn from(err: Error) -> (u8, u8) {
+        use Error::*;
+        match err {
+            ProcedureId { req_proc } => (req_proc, 1),
+            ProcedureVersion { req_proc } => (req_proc, 2),
+            SysexChecksum { req_proc } => (req_proc, 3),
+            SysexSize { req_proc } => (req_proc, 4),
+            MIDIOverrun { req_proc } => (req_proc, 5),
+            ProgramNumber { req_proc } => (req_proc, 6),
+            UserProgramNumber { req_proc } => (req_proc, 7),
+            BankNumber { req_proc } => (req_proc, 8),
+            DataCount { req_proc } => (req_proc, 9),
+            OSCommand { req_proc } => (req_proc, 10),
+            OSCommandMode { req_proc } => (req_proc, 11),
+            Unknown { req_proc, code } => (req_proc, code),
+        }
+    }
+}
+
+fn try_from(req_proc: u8, code: u8) -> Result<u8, Error> {
+    use Error::*;
+
+    match code {
+        0 => Ok(req_proc),
+        1 => Err(ProcedureId { req_proc }),
+        2 => Err(ProcedureVersion { req_proc }),
+        3 => Err(SysexChecksum { req_proc }),
+        4 => Err(SysexSize { req_proc }),
+        5 => Err(MIDIOverrun { req_proc }),
+        6 => Err(ProgramNumber { req_proc }),
+        7 => Err(UserProgramNumber { req_proc }),
+        8 => Err(BankNumber { req_proc }),
+        9 => Err(DataCount { req_proc }),
+        10 => Err(OSCommand { req_proc }),
+        11 => Err(OSCommandMode { req_proc }),
+        other => Err(Unknown { req_proc, code: other }),
     }
 }

--- a/src/jstation/sysex.rs
+++ b/src/jstation/sysex.rs
@@ -54,7 +54,8 @@ impl BufferBuilder {
 
     #[track_caller]
     pub fn push_variable_size_data(&mut self, data: impl ExactSizeIterator<Item = u8>) {
-        let len: u16 = (data.len() / 2)
+        let len: u16 = data
+            .len()
             .try_into()
             .expect("variable size data length overflow");
 
@@ -68,6 +69,17 @@ impl BufferBuilder {
 
     pub fn build(mut self) -> Vec<u8> {
         self.buf.extend([self.checksum, midi::sysex::END_TAG]);
+
+        // Set to true to dump buffers
+        if false {
+            println!(
+                "Buffer {:?}\n",
+                self.buf
+                    .iter()
+                    .map(|byte| format!("x{byte:02x}"))
+                    .collect::<Vec<String>>(),
+            );
+        }
 
         self.buf
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ pub fn main() -> iced::Result {
     use iced::Application;
     ui::App::run(iced::Settings {
         window: iced::window::Settings {
-            size: (830, 780),
+            size: (800, 780),
             ..Default::default()
         },
         ..Default::default()

--- a/src/ui/jstation.rs
+++ b/src/ui/jstation.rs
@@ -1,7 +1,7 @@
 use std::{cell::Cell, sync::Arc};
 
 use crate::{
-    jstation::{self, procedure, Error, Listener, Message},
+    jstation::{self, procedure, Error, Listener, Message, Program},
     midi,
 };
 
@@ -58,6 +58,10 @@ impl Interface {
 
     pub fn reload_program(&mut self) -> Result<(), Error> {
         self.iface.reload_program()
+    }
+
+    pub fn store_program(&mut self, prog: &Program) -> Result<(), Error> {
+        self.iface.store_program(prog)
     }
 
     pub fn send_cc(&mut self, cc: midi::CC) -> Result<(), Error> {

--- a/src/ui/jstation.rs
+++ b/src/ui/jstation.rs
@@ -56,6 +56,10 @@ impl Interface {
         self.iface.request_program(id)
     }
 
+    pub fn reload_program(&mut self) -> Result<(), Error> {
+        self.iface.reload_program()
+    }
+
     pub fn send_cc(&mut self, cc: midi::CC) -> Result<(), Error> {
         self.iface.send_cc(cc)
     }

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -9,6 +9,7 @@ pub enum Button {
     ModalClose,
     ListItem,
     ListItemSelected,
+    Store,
 }
 
 impl button::StyleSheet for Button {
@@ -25,13 +26,13 @@ impl button::StyleSheet for Button {
                 ..appearance
             },
             ListItem => button::Appearance {
-                background: None,
-                text_color: Color::from_rgb(0.5, 0.5, 0.55),
+                background: Some(Background::Color(Color::from_rgba(0.1, 0.1, 0.1, 0.1))),
+                text_color: Color::from_rgb(0.6, 0.6, 0.65),
                 ..appearance
             },
-            ListItemSelected => button::Appearance {
+            ListItemSelected | Store => button::Appearance {
                 background: Some(Background::Color(Color::from_rgb(0.55, 0.0, 0.0))),
-                text_color: Color::from_rgb(0.5, 0.5, 0.55),
+                text_color: Color::from_rgb(0.9, 0.9, 0.95),
                 ..appearance
             },
             ModalClose => button::Appearance {
@@ -54,12 +55,12 @@ impl button::StyleSheet for Button {
             },
             ListItem => button::Appearance {
                 background: Some(Background::Color(Color::from_rgb(0.2, 0.2, 0.2))),
-                text_color: Color::from_rgb(0.5, 0.5, 0.55),
+                text_color: Color::from_rgb(0.6, 0.6, 0.65),
                 ..appearance
             },
-            ListItemSelected => button::Appearance {
-                background: Some(Background::Color(Color::from_rgb(0.55, 0.0, 0.0))),
-                text_color: Color::from_rgb(0.5, 0.5, 0.55),
+            ListItemSelected | Store => button::Appearance {
+                background: Some(Background::Color(Color::from_rgb(0.75, 0.0, 0.0))),
+                text_color: Color::WHITE,
                 ..appearance
             },
             ModalClose => button::Appearance {

--- a/src/ui/widget.rs
+++ b/src/ui/widget.rs
@@ -16,7 +16,7 @@ pub const DEFAULT_DSP_WIDTH: Length = Length::Units(622);
 pub const DSP_PROGRAM_SPACING: Length = Length::Units(10);
 
 pub fn button<'a, Message>(title: &str) -> Button<'a, Message, iced::Renderer> {
-    Button::new(text(title).size(15)).style(style::Button::Default.into())
+    Button::new(text(title).size(15))
 }
 
 pub fn checkbox<'a, Message, F>(
@@ -96,8 +96,9 @@ where
 {
     container(
         column![
-            button("X")
+            Button::new(text("X").size(15).horizontal_alignment(Horizontal::Center))
                 .on_press(on_hide)
+                .width(Length::Units(25))
                 .style(style::Button::ModalClose.into()),
             vertical_space(Length::Units(10)),
             element.into(),

--- a/src/ui/widget.rs
+++ b/src/ui/widget.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, fmt, marker::PhantomData};
 
 use iced::{
-    alignment::{Horizontal, Vertical},
+    alignment::Horizontal,
     widget::{
         column, container, row, text, vertical_space, Button, Checkbox, Column, Container,
         PickList, Radio, Text, Toggler,
@@ -88,27 +88,34 @@ pub fn value_label(text: impl ToString) -> Text<'static, iced::Renderer> {
 }
 
 pub fn modal<'a, Message>(
+    title: &str,
     element: impl Into<Element<'a, Message, iced::Renderer>>,
     on_hide: Message,
 ) -> Container<'a, Message>
 where
     Message: 'a + Clone,
 {
+    const CLOSE_BTN_WIDTH: u16 = 25;
+
     container(
         column![
-            Button::new(text("X").size(15).horizontal_alignment(Horizontal::Center))
-                .on_press(on_hide)
-                .width(Length::Units(25))
-                .style(style::Button::ModalClose.into()),
-            vertical_space(Length::Units(10)),
-            element.into(),
+            row![
+                container(text(title)).width(Length::Fill).center_x(),
+                Button::new(text("X").size(15).horizontal_alignment(Horizontal::Center))
+                    .on_press(on_hide)
+                    .width(Length::Units(CLOSE_BTN_WIDTH))
+                    .style(style::Button::ModalClose.into()),
+            ]
+            .align_items(Alignment::Center),
+            vertical_space(Length::Units(30)),
+            container(element.into()).width(Length::Fill).center_x(),
         ]
-        .align_items(Alignment::End),
+        .width(Length::Units(350)),
     )
     .width(Length::Fill)
+    .center_x()
     .height(Length::Fill)
-    .align_x(Horizontal::Center)
-    .align_y(Vertical::Center)
+    .center_y()
 }
 
 pub fn pick_list<'a, T, Message>(


### PR DESCRIPTION
This PR adds store and undo features. Programs can changes be undone or copied onto themselves or to another program. Use can also copy a factory program to a user program.

Program identification on startup is improved. Previously, inactive parameters where also checked which lead to miss-identifications. Note that gstation-edit is affected though the issue is masked since the first program is selected in this case.