### PR TITLE
Fix mouse wheel discontinuity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,9 +326,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
@@ -974,9 +974,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
+checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -989,9 +989,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -999,15 +999,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
+checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1017,9 +1017,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
 
 [[package]]
 name = "futures-lite"
@@ -1038,9 +1038,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
+checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1049,21 +1049,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
+checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
 
 [[package]]
 name = "futures-task"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
 
 [[package]]
 name = "futures-util"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1265,8 +1265,8 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "iced"
-version = "0.6.0"
-source = "git+https://github.com/fengalin/iced?tag=0.7.0-subscription-unfold-none-handling#0246fc130cefa585a71ecad46467a6692baebbe0"
+version = "0.7.0"
+source = "git+https://github.com/fengalin/iced?tag=0.7.9-subscription-unfold-none-handling#6ecb44e78951a2156f0b3ca8b6787a5c03a46c2e"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -1280,9 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "iced_audio"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d60c756a07ccf31395273f90d9c7a8eca9397c20391f60fac691b0cdde49824"
+checksum = "1f0eb3bb934e83cb147bc2cbf1faef2ac92ef5f6688a4f702d6faa8768a0ea8a"
 dependencies = [
  "iced_core",
  "iced_graphics",
@@ -1292,18 +1292,18 @@ dependencies = [
 
 [[package]]
 name = "iced_core"
-version = "0.6.2"
-source = "git+https://github.com/fengalin/iced?tag=0.7.0-subscription-unfold-none-handling#0246fc130cefa585a71ecad46467a6692baebbe0"
+version = "0.7.0"
+source = "git+https://github.com/fengalin/iced?tag=0.7.9-subscription-unfold-none-handling#6ecb44e78951a2156f0b3ca8b6787a5c03a46c2e"
 dependencies = [
  "bitflags",
+ "instant",
  "palette",
- "wasm-timer",
 ]
 
 [[package]]
 name = "iced_futures"
 version = "0.5.1"
-source = "git+https://github.com/fengalin/iced?tag=0.7.0-subscription-unfold-none-handling#0246fc130cefa585a71ecad46467a6692baebbe0"
+source = "git+https://github.com/fengalin/iced?tag=0.7.9-subscription-unfold-none-handling#6ecb44e78951a2156f0b3ca8b6787a5c03a46c2e"
 dependencies = [
  "futures",
  "log",
@@ -1314,8 +1314,8 @@ dependencies = [
 
 [[package]]
 name = "iced_glow"
-version = "0.5.1"
-source = "git+https://github.com/fengalin/iced?tag=0.7.0-subscription-unfold-none-handling#0246fc130cefa585a71ecad46467a6692baebbe0"
+version = "0.6.0"
+source = "git+https://github.com/fengalin/iced?tag=0.7.9-subscription-unfold-none-handling#6ecb44e78951a2156f0b3ca8b6787a5c03a46c2e"
 dependencies = [
  "bytemuck",
  "euclid",
@@ -1329,8 +1329,8 @@ dependencies = [
 
 [[package]]
 name = "iced_graphics"
-version = "0.5.0"
-source = "git+https://github.com/fengalin/iced?tag=0.7.0-subscription-unfold-none-handling#0246fc130cefa585a71ecad46467a6692baebbe0"
+version = "0.6.0"
+source = "git+https://github.com/fengalin/iced?tag=0.7.9-subscription-unfold-none-handling#6ecb44e78951a2156f0b3ca8b6787a5c03a46c2e"
 dependencies = [
  "bitflags",
  "bytemuck",
@@ -1346,8 +1346,8 @@ dependencies = [
 
 [[package]]
 name = "iced_lazy"
-version = "0.3.0"
-source = "git+https://github.com/fengalin/iced?tag=0.7.0-subscription-unfold-none-handling#0246fc130cefa585a71ecad46467a6692baebbe0"
+version = "0.4.0"
+source = "git+https://github.com/fengalin/iced?tag=0.7.9-subscription-unfold-none-handling#6ecb44e78951a2156f0b3ca8b6787a5c03a46c2e"
 dependencies = [
  "iced_native",
  "ouroboros",
@@ -1355,8 +1355,8 @@ dependencies = [
 
 [[package]]
 name = "iced_native"
-version = "0.7.0"
-source = "git+https://github.com/fengalin/iced?tag=0.7.0-subscription-unfold-none-handling#0246fc130cefa585a71ecad46467a6692baebbe0"
+version = "0.8.0"
+source = "git+https://github.com/fengalin/iced?tag=0.7.9-subscription-unfold-none-handling#6ecb44e78951a2156f0b3ca8b6787a5c03a46c2e"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -1368,8 +1368,8 @@ dependencies = [
 
 [[package]]
 name = "iced_style"
-version = "0.5.1"
-source = "git+https://github.com/fengalin/iced?tag=0.7.0-subscription-unfold-none-handling#0246fc130cefa585a71ecad46467a6692baebbe0"
+version = "0.6.0"
+source = "git+https://github.com/fengalin/iced?tag=0.7.9-subscription-unfold-none-handling#6ecb44e78951a2156f0b3ca8b6787a5c03a46c2e"
 dependencies = [
  "iced_core",
  "once_cell",
@@ -1378,8 +1378,8 @@ dependencies = [
 
 [[package]]
 name = "iced_wgpu"
-version = "0.7.0"
-source = "git+https://github.com/fengalin/iced?tag=0.7.0-subscription-unfold-none-handling#0246fc130cefa585a71ecad46467a6692baebbe0"
+version = "0.8.0"
+source = "git+https://github.com/fengalin/iced?tag=0.7.9-subscription-unfold-none-handling#6ecb44e78951a2156f0b3ca8b6787a5c03a46c2e"
 dependencies = [
  "bitflags",
  "bytemuck",
@@ -1398,8 +1398,8 @@ dependencies = [
 
 [[package]]
 name = "iced_winit"
-version = "0.6.0"
-source = "git+https://github.com/fengalin/iced?tag=0.7.0-subscription-unfold-none-handling#0246fc130cefa585a71ecad46467a6692baebbe0"
+version = "0.7.0"
+source = "git+https://github.com/fengalin/iced?tag=0.7.9-subscription-unfold-none-handling#6ecb44e78951a2156f0b3ca8b6787a5c03a46c2e"
 dependencies = [
  "iced_futures",
  "iced_graphics",
@@ -1692,9 +1692,9 @@ dependencies = [
 
 [[package]]
 name = "midir"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e18ef2d47e2bb864c0aced41b3a809a1fe1ef0e03927c58577f694296a56f837"
+checksum = "a456444d83e7ead06ae6a5c0a215ed70282947ff3897fb45fcb052b757284731"
 dependencies = [
  "alsa",
  "bitflags",
@@ -1998,9 +1998,9 @@ dependencies = [
 
 [[package]]
 name = "owned_ttf_parser"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a5f3c7ca08b6879e7965fb25e24d1f5eeb32ea73f9ad99b3854778a38c57e93"
+checksum = "e25e9fb15717794fae58ab55c26e044103aad13186fbb625893f9a3bbcc24228"
 dependencies = [
  "ttf-parser",
 ]
@@ -2820,9 +2820,9 @@ checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,12 @@ bitflags = "1.3.2"
 env_logger = "0.10"
 flume = "0.10.13"
 futures = "0.3.25"
-iced = { version = "0.6", features = [ "default_system_font", "smol" ] }
-iced_audio = "0.9"
-iced_core = "0.6"
-iced_lazy = "0.3.0"
-iced_native = "0.7"
-iced_wgpu = "0.7"
+iced = { version = "0.7", features = [ "default_system_font", "smol" ] }
+iced_audio = "0.10"
+iced_core = "0.7"
+iced_lazy = "0.4"
+iced_native = "0.8"
+iced_wgpu = "0.8"
 jstation_derive = { path = "jstation_derive" }
 log = { version = "0.4", features = ["release_max_level_info"] }
 midir = "0.9"
@@ -34,9 +34,9 @@ thiserror = "1.0"
 lto = true
 
 [patch.crates-io]
-iced = { git = "https://github.com/fengalin/iced", tag = "0.7.0-subscription-unfold-none-handling" }
-iced_core = { git = "https://github.com/fengalin/iced", tag = "0.7.0-subscription-unfold-none-handling" }
-iced_graphics = { git = "https://github.com/fengalin/iced", tag = "0.7.0-subscription-unfold-none-handling" }
-iced_lazy = { git = "https://github.com/fengalin/iced", tag = "0.7.0-subscription-unfold-none-handling" }
-iced_native = { git = "https://github.com/fengalin/iced", tag = "0.7.0-subscription-unfold-none-handling" }
-iced_wgpu = { git = "https://github.com/fengalin/iced", tag = "0.7.0-subscription-unfold-none-handling" }
+iced = { git = "https://github.com/fengalin/iced", tag = "0.7.9-subscription-unfold-none-handling" }
+iced_core = { git = "https://github.com/fengalin/iced", tag = "0.7.9-subscription-unfold-none-handling" }
+iced_graphics = { git = "https://github.com/fengalin/iced", tag = "0.7.9-subscription-unfold-none-handling" }
+iced_lazy = { git = "https://github.com/fengalin/iced", tag = "0.7.9-subscription-unfold-none-handling" }
+iced_native = { git = "https://github.com/fengalin/iced", tag = "0.7.9-subscription-unfold-none-handling" }
+iced_wgpu = { git = "https://github.com/fengalin/iced", tag = "0.7.9-subscription-unfold-none-handling" }

--- a/src/jstation/mod.rs
+++ b/src/jstation/mod.rs
@@ -197,7 +197,7 @@ impl JStationImpl for JStation {
                 match cv.msg {
                     CC(cc) => match self.dsp.set_cc(cc) {
                         Ok(Some(_)) => self.update_has_changed(),
-                        Ok(None) => log::debug!("Unhandled {cc:?}"),
+                        Ok(None) => log::trace!("Unchanged value for {cc:?}"),
                         Err(err) => log::warn!("{err}"),
                     },
                     ProgramChange(prog_id) => {


### PR DESCRIPTION
This PR solves an issue with iced_audio widgets: when the user changed presets and a parameter was set to a discontinuous value, if the user attempted to change the value using the mouse wheel, the change started from previous
value.